### PR TITLE
Feature/ssl

### DIFF
--- a/app/v1/app.js
+++ b/app/v1/app.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const helmet = require('helmet');
 let app = express();
 
 //custom modules
@@ -34,6 +35,8 @@ const moduleConfig = require('./module-config/controller.js');
 const auth = require('./middleware/auth.js');
 
 function exposeRoutes () {
+	// use helmet middleware for security
+	app.use(helmet());
 	// extend response builder to all routes
 	app.route("*").all(parcel.extendExpress);
 

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -14,9 +14,11 @@ function transformModuleConfig (isProduction, info, next) {
 
     var concatPort = "";
     var protocol = "http://";
-    if(settings.policyServerPortSSL && settings.policyServerPortSSL != 443){
+    if(settings.policyServerPortSSL){
         protocol = "https://";
-        concatPort = ":" + settings.policyServerPortSSL;
+        if(settings.policyServerPortSSL != 443){
+            concatPort = ":" + settings.policyServerPortSSL;
+        }
     }else if(!settings.policyServerPortSSL && settings.policyServerPort != 80){
         concatPort = ":" + settings.policyServerPort;
     }

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -12,6 +12,15 @@ function transformModuleConfig (isProduction, info, next) {
         return secondObj.seconds;
     });
 
+    var concatPort = "";
+    var protocol = "http://";
+    if(settings.policyServerPortSSL && settings.policyServerPortSSL != 443){
+        protocol = "https://";
+        concatPort = ":" + settings.policyServerPortSSL;
+    }else if(!settings.policyServerPortSSL && settings.policyServerPort != 80){
+        concatPort = ":" + settings.policyServerPort;
+    }
+
     next(null, {
         "preloaded_pt": base.preloaded_pt,
         "exchange_after_x_ignition_cycles": base.exchange_after_x_ignition_cycles,
@@ -21,7 +30,7 @@ function transformModuleConfig (isProduction, info, next) {
         "seconds_between_retries": retrySeconds,
         "endpoints": {
             "0x07": {
-                default: ["http://" + settings.policyServerHost + ":" + settings.policyServerPort + "/api/v1/" + (isProduction ? "production" : "staging") + "/policy"]
+                default: [ protocol + settings.policyServerHost + concatPort + "/api/v1/" + (isProduction ? "production" : "staging") + "/policy"]
             },
             "0x04": {
                 default: [base.endpoint_0x04]

--- a/documentation/guides/docs/Getting Started/Installation/index.md
+++ b/documentation/guides/docs/Getting Started/Installation/index.md
@@ -16,6 +16,9 @@ Here are the environment variables that will most likely be used:
 
 * `POLICY_SERVER_HOST`: The hostname or public IP address which the server runs on.
 * `POLICY_SERVER_PORT`: The port which the server runs on. It is optional and the default is 3000.
+* `POLICY_SERVER_PORT_SSL`: The port which the server should listen for SSL connections on (typically 443). It is optional and the default is `null` (do not listen for SSL connections).
+* `SSL_CERTIFICATE_FILENAME`: The filename of the SSL certificate located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
+* `SSL_PRIVATE_KEY_FILENAME`: The filename of the SSL certificate's private key located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
 * `SHAID_PUBLIC_KEY`: A public key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
 * `SHAID_SECRET_KEY`: A secret key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
 * `STAGING_PG_USER`: The name of the user to allow the server access the database (staging mode)

--- a/documentation/guides/docs/Getting Started/Security/index.md
+++ b/documentation/guides/docs/Getting Started/Security/index.md
@@ -1,6 +1,15 @@
 # Security
 For your convenience, we have implemented the following security features into the Policy Server.
 
+### HTTPS Connections (SSL/TLS)
+HTTPS connections (disabled by default) can be enabled by doing the following:
+* Store your SSL Certificate and Private Key files in the `./customizable/ssl` directory
+* Set your `POLICY_SERVER_PORT_SSL` environment variable to your desired secure port (typically 443)
+* Set your `SSL_CERTIFICATE_FILENAME` environment variable to the filename of your SSL Certificate file
+* Set your `SSL_PRIVATE_KEY_FILENAME` environment variable to the filename of your Private Key file
+* If  you are unable to modify your environment variables, you may define these settings in the `./settings.js` configuration file
+* Restart your Policy Server and navigate to your server's hostname on the secure port!
+
 ### Basic Authentication
 You may optionally require your Policy Server administrators to enter a password before being able to access the user interface. We recommend using a more secure method of authentication in accordance to your company's IT security standards, but provide this basic authentication feature for convenience.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,6 +1616,11 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
@@ -2186,6 +2191,11 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
+    "content-security-policy-builder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz",
+      "integrity": "sha512-j+Nhmj1yfZAikJLImCvPJFE29x/UuBi+/MWqggGGc515JKaZrjuei2RhULJmy0MsstW3E3htl002bwmBNMKr7w=="
+    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -2669,6 +2679,11 @@
         "assert-plus": "1.0.0"
       }
     },
+    "dasherize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
+      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -2870,6 +2885,11 @@
         "randombytes": "2.0.6"
       }
     },
+    "dns-prefetch-control": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz",
+      "integrity": "sha1-YN20V3dOF48flBXwyrsOhbCzALI="
+    },
     "dom-converter": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
@@ -2935,6 +2955,11 @@
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
       }
+    },
+    "dont-sniff-mimetype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.0.0.tgz",
+      "integrity": "sha1-WTKJDcn04vGeXrAqIAJuXl78j1g="
     },
     "dotenv": {
       "version": "4.0.0",
@@ -3144,6 +3169,11 @@
       "requires": {
         "fill-range": "2.2.3"
       }
+    },
+    "expect-ct": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.1.0.tgz",
+      "integrity": "sha1-UnNWeN4YUwiQ2Ne5XwrGNkCVgJQ="
     },
     "express": {
       "version": "4.16.0",
@@ -3420,6 +3450,11 @@
       "requires": {
         "map-cache": "0.2.2"
       }
+    },
+    "frameguard": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.0.0.tgz",
+      "integrity": "sha1-e8rUae57lukdEs6zlZx4I1qScuk="
     },
     "fresh": {
       "version": "0.5.2",
@@ -4680,6 +4715,42 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "helmet": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.12.0.tgz",
+      "integrity": "sha512-CgkctpvreQLL6X3EL2Igs/92+75ZFIsrob9/Rdwf2hQCBGH/DxLk4xFPxAAl6jYnnus/YXfFEVXHEJf8TJTwlA==",
+      "requires": {
+        "dns-prefetch-control": "0.1.0",
+        "dont-sniff-mimetype": "1.0.0",
+        "expect-ct": "0.1.0",
+        "frameguard": "3.0.0",
+        "helmet-csp": "2.7.0",
+        "hide-powered-by": "1.0.0",
+        "hpkp": "2.0.0",
+        "hsts": "2.1.0",
+        "ienoopen": "1.0.0",
+        "nocache": "2.0.0",
+        "referrer-policy": "1.1.0",
+        "x-xss-protection": "1.1.0"
+      }
+    },
+    "helmet-csp": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.7.0.tgz",
+      "integrity": "sha512-IGIAkWnxjRbgMXFA2/kmDqSIrIaSfZ6vhMHlSHw7jm7Gm9nVVXqwJ2B1YEpYrJsLrqY+w2Bbimk7snux9+sZAw==",
+      "requires": {
+        "camelize": "1.0.0",
+        "content-security-policy-builder": "2.0.0",
+        "dasherize": "2.0.0",
+        "lodash.reduce": "4.6.0",
+        "platform": "1.3.5"
+      }
+    },
+    "hide-powered-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
+      "integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4711,6 +4782,16 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
+    },
+    "hpkp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
+      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
+    },
+    "hsts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
+      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -4868,6 +4949,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
+    },
+    "ienoopen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.0.0.tgz",
+      "integrity": "sha1-NGpCj0dKrI9QzzeE6i0PFvYr2ms="
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -5457,6 +5543,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
     "lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -5902,6 +5993,11 @@
       "requires": {
         "lower-case": "1.1.4"
       }
+    },
+    "nocache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
+      "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
     },
     "node-dir": {
       "version": "0.1.17",
@@ -6623,6 +6719,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
     },
     "popper.js": {
       "version": "1.12.9",
@@ -8987,6 +9088,11 @@
         "balanced-match": "0.4.2"
       }
     },
+    "referrer-policy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.1.0.tgz",
+      "integrity": "sha1-NXdOtzW/UPtsB46DM0tHI1AgfXk="
+    },
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
@@ -10920,6 +11026,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x-xss-protection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
+      "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
     },
     "xml-char-classes": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db-migrate-pg": "0.2.4",
     "dotenv": "4.0.0",
     "express": "4.16.0",
+    "helmet": "^3.12.0",
     "jquery": "3.2.1",
     "lodash.get": "4.4.2",
     "needle": "2.1.0",

--- a/settings.js
+++ b/settings.js
@@ -9,6 +9,11 @@ module.exports = {
     policyServerHost: process.env.POLICY_SERVER_HOST || "localhost",
     //the port this server will be running in
     policyServerPort: process.env.POLICY_SERVER_PORT || 3000,
+    //the SSL certificate files and secure port to listen for secure connections with
+    //files should be stored in ./customizable/ssl
+    sslPrivateKeyFilename: process.env.SSL_PRIVATE_KEY_FILENAME || null,
+    sslCertificateFilename: process.env.SSL_CERTIFICATE_FILENAME || null,
+    policyServerPortSSL: process.env.POLICY_SERVER_PORT_SSL || null, // typically 443
     //what kind of auth to enforce? "basic" or null (no authentication)
     authType: process.env.AUTH_TYPE || null,
     //an optional password users must enter to access the Policy Server interface when paired with "basic" authType


### PR DESCRIPTION
Fixes #69 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Follow the directions in the "Security" section of the Policy Server guides to attach an SSL Certificate, Private Key file, and set a secure port to listen on, then confirm that requests are fulfilled when accessing the Policy Server UI and API endpoints using secure URLs.

### Summary
Adds optional support to enable listening for HTTPS connections. Dynamically changes the 0x07 policy table update URL depending on whether or not HTTPS connections are enabled and which port they're enabled on.

### Changelog
##### Enhancements
* Added ability to configure support for HTTPS (SSL/TLS) connections