### PR TITLE
Feature/blacklist apps

### DIFF
--- a/app/v1/applications/controller.js
+++ b/app/v1/applications/controller.js
@@ -2,6 +2,7 @@ const app = require('../app');
 const helper = require('./helper.js');
 const sql = require('./sql.js');
 const flow = app.locals.flow;
+const async = require('async');
 
 function get (req, res, next) {
 	//prioritize id, uuid, approval status, in that order.
@@ -43,28 +44,29 @@ function actionPost (req, res, next) {
 		return res.parcel.deliver();
 	}
 
-    //modify the existing entry in the database to change the approval status
-    app.locals.db.sqlCommand(sql.changeAppApprovalStatus(req.body.id, req.body.approval_status, (req.body.denial_message || null)), function (err, results) {
-        if (err) {
-            app.locals.log.error(err);
-            return res.parcel.setStatus(500).deliver();
-        }
-
-		if (req.body.blacklist !== null) {
-			let blacklistCommand = req.body.blacklist ?
-				app.locals.db.sqlCommand.bind(null, sql.insertAppBlacklist(req.body))
-				: app.locals.db.sqlCommand.bind(null, sql.deleteAppBlacklist(req.body.uuid));
-
-			blacklistCommand(function (err, results) {
-				if (err) {
-					app.locals.log.error(err);
-					return res.parcel.setStatus(500).deliver();
+	app.locals.db.runAsTransaction(function (client, callback) {
+		async.waterfall([
+			// Blacklist/Unblacklist app
+			function (callback) {
+				if (req.body.blacklist) {
+					client.getOne(sql.insertAppBlacklist(req.body), callback);
+				} else {
+					client.getOne(sql.deleteAppBlacklist(req.body.uuid), callback);
 				}
-			});
+			},
+			// Update approval status for app
+			function (blacklist, callback) {
+				client.getOne(sql.changeAppApprovalStatus(req.body.id, req.body.approval_status, (req.body.denial_message || null)), callback);
+			}
+		], callback);
+	}, function (err, response) {
+		if (err) {
+			app.locals.log.error(err);
+			return res.parcel.setStatus(500).deliver();
+		} else {
+			return res.parcel.setStatus(200).deliver();
 		}
-
-        return res.parcel.setStatus(200).deliver();
-    });
+	});
 }
 
 function autoPost (req, res, next) {

--- a/app/v1/applications/controller.js
+++ b/app/v1/applications/controller.js
@@ -49,6 +49,20 @@ function actionPost (req, res, next) {
             app.locals.log.error(err);
             return res.parcel.setStatus(500).deliver();
         }
+
+		if (req.body.blacklist !== null) {
+			let blacklistCommand = req.body.blacklist ?
+				app.locals.db.sqlCommand.bind(null, sql.insertAppBlacklist(req.body))
+				: app.locals.db.sqlCommand.bind(null, sql.deleteAppBlacklist(req.body.uuid));
+
+			blacklistCommand(function (err, results) {
+				if (err) {
+					app.locals.log.error(err);
+					return res.parcel.setStatus(500).deliver();
+				}
+			});
+		}
+
         return res.parcel.setStatus(200).deliver();
     });
 }

--- a/app/v1/applications/helper.js
+++ b/app/v1/applications/helper.js
@@ -50,7 +50,8 @@ function createAppInfoFlow (filterTypeFunc, value) {
 		appPermissions: setupSql.bind(null, sql.getApp.permissions[filterTypeFunc](value)),
 		appVendors: setupSql.bind(null, sql.getApp.vendor[filterTypeFunc](value)),
 		appCategories: setupSql.bind(null, sql.getApp.category[filterTypeFunc](value)),
-		appAutoApprovals: setupSql.bind(null, sql.getApp.autoApproval[filterTypeFunc](value))
+		appAutoApprovals: setupSql.bind(null, sql.getApp.autoApproval[filterTypeFunc](value)),
+		appBlacklist: setupSql.bind(null, sql.getApp.blacklist[filterTypeFunc](value))
 	}, {method: 'parallel', eventLoop: true});
 
 	return app.locals.flow([getAppFlow, model.constructFullAppObjs], {method: "waterfall", eventLoop: true});
@@ -63,13 +64,16 @@ function storeApps (includeApprovalStatus, apps, callback) {
     function recStore(includeApprovalStatus, theseApps, cb){
         const fullFlow = flow([
             //first check if the apps need to be stored in the database
-            flow(flame.map(theseApps, checkNeedsInsertion), {method: "parallel"}), 
-            filterApps.bind(null, includeApprovalStatus), 
+            flow(flame.map(theseApps, checkNeedsInsertion), {method: "parallel"}),
+            filterApps.bind(null, includeApprovalStatus),
             //each app surviving the filter should be checked with the app_auto_approval table to see if it its status
             //should change to be accepted
             function (appObjs, next) {
                 flame.async.map(appObjs, autoApprovalModifier, next);
             },
+			function (appObjs, next) {
+				flame.async.map(appObjs, autoBlacklistModifier, next);
+			},
             function (appObjs, next) {
                 flame.async.map(appObjs, model.storeApp, next);
             }
@@ -83,12 +87,12 @@ function storeApps (includeApprovalStatus, apps, callback) {
                 let appID = res[res.length - 1];
                 if(appID && queue[queue.length - 1] !== appID){ // ensures that the appID is not null and not already in the queue
                     queue.push(appID);
-                } 
+                }
                 if(res.length !== theseApps.length){
                     let appsLeftover = theseApps.slice(res.length);
                     return recStore(includeApprovalStatus, appsLeftover, cb);
                 }
-            } 
+            }
             cb();
         });
     }
@@ -113,7 +117,7 @@ function checkNeedsInsertion (appObj, next) {
             const incomingDate = new Date(timestamp);
             const currentDate = new Date(dbTimestamp);
             if (incomingDate > currentDate) {
-                //the app in the policy server's database is outdated! 
+                //the app in the policy server's database is outdated!
                 next(null, appObj);
             }
             else { //app is already there
@@ -152,8 +156,18 @@ function autoApprovalModifier (appObj, next) {
         if (res.length > 0) {
             appObj.approval_status = 'ACCEPTED';
         }
-        next(null, appObj); 
+        next(null, appObj);
     });
+}
+
+// Auto deny new application versions of an app that is blacklisted
+function autoBlacklistModifier (appObj, next) {
+	db.sqlCommand(sql.getBlacklistedApps(appObj.uuid), function (err, res) {
+		if (res.length > 0) {
+			appObj.approval_status = 'DENIED';
+		}
+		next(null, appObj);
+	});
 }
 
 // checks a retry queue of app IDs to requery their information from SHAID and attempt insertion into the database
@@ -171,13 +185,16 @@ function attemptRetry(milliseconds, retryQueue){
                 function(apps, callback){
                     const fullFlow = flow([
                         //first check if the apps need to be stored in the database
-                        flow(flame.map(apps, checkNeedsInsertion), {method: "parallel"}), 
-                        filterApps.bind(null, false), 
+                        flow(flame.map(apps, checkNeedsInsertion), {method: "parallel"}),
+                        filterApps.bind(null, false),
                         //each app surviving the filter should be checked with the app_auto_approval table to see if it its status
                         //should change to be accepted
                         function (appObjs, callback) {
                             flame.async.map(appObjs, autoApprovalModifier, callback);
                         },
+						function (appObjs, callback) {
+							flame.async.map(appObjs, autoBlacklistModifier, callback);
+						},
                         function (appObjs, callback) {
                             flame.async.map(appObjs, model.storeApp, callback);
                         }

--- a/app/v1/applications/model.js
+++ b/app/v1/applications/model.js
@@ -14,16 +14,21 @@ function constructFullAppObjs (res, next) {
     const appVendors = res.appVendors;
     const appCategories = res.appCategories;
     const appAutoApprovals = res.appAutoApprovals;
+    const appBlacklist = res.appBlacklist;
 
     //convert appCategories and appAutoApprovals to hash by id
     const hashedCategories = {};
     const hashedAutoApproval = {};
+    const hashedBlacklist = {};
 
     for (let i = 0; i < appCategories.length; i++) {
         hashedCategories[appCategories[i].id] = appCategories[i].display_name;
     }
     for (let i = 0; i < appAutoApprovals.length; i++) {
         hashedAutoApproval[appAutoApprovals[i].app_uuid] = true;
+    }
+    for (let i = 0; i < appBlacklist.length; i++) {
+        hashedBlacklist[appBlacklist[i].app_uuid] = true;
     }
 
     //convert appBase to hash by id for fast assignment of other information
@@ -41,6 +46,13 @@ function constructFullAppObjs (res, next) {
         else {
             hashedApps[appBase[i].id].is_auto_approved_enabled = false;
         }
+
+        if (hashedBlacklist[appBase[i].app_uuid]) {
+            hashedApps[appBase[i].id].is_blacklisted = true;
+        } else {
+            hashedApps[appBase[i].id].is_blacklisted = false;
+        }
+
         delete hashedApps[appBase[i].id].app_uuid;
         hashedApps[appBase[i].id].countries = [];
         hashedApps[appBase[i].id].display_names = [];

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -363,13 +363,14 @@ function getAppBlacklist (id) {
         .toString();
 }
 
-function getBlacklistedApps (uuid) {
-    if (uuid) {
+function getBlacklistedApps (uuids) {
+    if (!Array.isArray(uuids)) {
+        uuids = [uuids];
+    }
+    if (uuids) {
         return sql.select('app_uuid')
             .from('app_blacklist')
-            .where({
-                app_uuid: uuid
-            })
+            .where(sql.in('app_uuid', uuids))
             .toString();
     } else {
         return sql.select('app_uuid')

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -314,6 +314,32 @@ function insertAppAutoApproval (obj) {
         .toString();
 }
 
+function insertAppBlacklist (obj) {
+    return sql.insert('app_blacklist', 'app_uuid')
+        .select(`'${obj.uuid}' AS app_uuid`)
+        .where(
+            sql.not(
+                sql.exists(
+                    sql.select('*')
+                        .from('app_blacklist ab')
+                        .where({
+                            'ab.app_uuid': obj.uuid
+                        })
+                )
+            )
+        )
+        .toString()
+}
+
+function deleteAppBlacklist (uuid) {
+    return sql.delete()
+        .from('app_blacklist')
+        .where({
+            app_uuid: uuid
+        })
+        .toString();
+}
+
 module.exports = {
     changeAppApprovalStatus: changeAppApprovalStatus,
     deleteAutoApproval: deleteAutoApproval,
@@ -354,6 +380,7 @@ module.exports = {
     insertAppCountries: insertAppCountries,
     insertAppDisplayNames: insertAppDisplayNames,
     insertAppPermissions: insertAppPermissions,
-    insertAppAutoApproval: insertAppAutoApproval
+    insertAppAutoApproval: insertAppAutoApproval,
+    insertAppBlacklist: insertAppBlacklist,
+    deleteAppBlacklist: deleteAppBlacklist
 }
-

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -328,15 +328,18 @@ function insertAppBlacklist (obj) {
                 )
             )
         )
+        .returning('*')
         .toString()
 }
 
 function deleteAppBlacklist (uuid) {
+    console.log("In deleteAppBlacklist");
     return sql.delete()
         .from('app_blacklist')
         .where({
             app_uuid: uuid
         })
+        .returning('*')
         .toString();
 }
 

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -364,19 +364,10 @@ function getAppBlacklist (id) {
 }
 
 function getBlacklistedApps (uuids) {
-    if (!Array.isArray(uuids)) {
-        uuids = [uuids];
-    }
-    if (uuids) {
-        return sql.select('app_uuid')
+    return sql.select('app_uuid')
             .from('app_blacklist')
             .where(sql.in('app_uuid', uuids))
             .toString();
-    } else {
-        return sql.select('app_uuid')
-            .from('app_blacklist')
-            .toString();
-    }
 }
 
 module.exports = {

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -333,7 +333,6 @@ function insertAppBlacklist (obj) {
 }
 
 function deleteAppBlacklist (uuid) {
-    console.log("In deleteAppBlacklist");
     return sql.delete()
         .from('app_blacklist')
         .where({
@@ -341,6 +340,42 @@ function deleteAppBlacklist (uuid) {
         })
         .returning('*')
         .toString();
+}
+
+function getAppBlacklistFilter (filterObj) {
+    return sql.select('app_blacklist.app_uuid')
+        .from('app_blacklist')
+        .join('(' + getAppInfoFilter(filterObj) + ') ai', {
+            'ai.app_uuid': 'app_blacklist.app_uuid'
+        })
+        .toString();
+}
+
+function getAppBlacklist (id) {
+    return sql.select('app_blacklist.app_uuid')
+        .from('app_blacklist')
+        .join('app_info', {
+            'app_blacklist.app_uuid': 'app_info.app_uuid'
+        })
+        .where({
+            id: id
+        })
+        .toString();
+}
+
+function getBlacklistedApps (uuid) {
+    if (uuid) {
+        return sql.select('app_uuid')
+            .from('app_blacklist')
+            .where({
+                app_uuid: uuid
+            })
+            .toString();
+    } else {
+        return sql.select('app_uuid')
+            .from('app_blacklist')
+            .toString();
+    }
 }
 
 module.exports = {
@@ -374,6 +409,10 @@ module.exports = {
         autoApproval: {
             multiFilter: getAppAutoApprovalFilter,
             idFilter: getAppAutoApproval
+        },
+        blacklist: {
+            multiFilter: getAppBlacklistFilter,
+            idFilter: getAppBlacklist
         }
     },
     timestampCheck: timestampCheck,
@@ -385,5 +424,6 @@ module.exports = {
     insertAppPermissions: insertAppPermissions,
     insertAppAutoApproval: insertAppAutoApproval,
     insertAppBlacklist: insertAppBlacklist,
-    deleteAppBlacklist: deleteAppBlacklist
+    deleteAppBlacklist: deleteAppBlacklist,
+    getBlacklistedApps: getBlacklistedApps
 }

--- a/app/v1/policy/helper.js
+++ b/app/v1/policy/helper.js
@@ -133,7 +133,7 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
         defaultFuncGroups: setupSqlCommand.bind(null, sql.getDefaultFunctionalGroups(isProduction)),
         preDataConsentFuncGroups: setupSqlCommand.bind(null, sql.getPreDataConsentFunctionalGroups(isProduction)),
         deviceFuncGroups: setupSqlCommand.bind(null, sql.getDeviceFunctionalGroups(isProduction)),
-        blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps())
+        blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps(requestedUuids))
     }, {method: 'parallel'});
     flame.flow([
         getAllDataFlow,

--- a/app/v1/policy/helper.js
+++ b/app/v1/policy/helper.js
@@ -133,7 +133,13 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
         defaultFuncGroups: setupSqlCommand.bind(null, sql.getDefaultFunctionalGroups(isProduction)),
         preDataConsentFuncGroups: setupSqlCommand.bind(null, sql.getPreDataConsentFunctionalGroups(isProduction)),
         deviceFuncGroups: setupSqlCommand.bind(null, sql.getDeviceFunctionalGroups(isProduction)),
-        blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps(requestedUuids))
+        blacklistedApps: function (callback) {
+            if (requestedUuids.length > 0) {
+                setupSqlCommand(sqlApps.getBlacklistedApps(requestedUuids), callback);
+            } else {
+                callback(null, []);
+            }
+        }
     }, {method: 'parallel'});
     flame.flow([
         getAllDataFlow,

--- a/app/v1/policy/helper.js
+++ b/app/v1/policy/helper.js
@@ -117,7 +117,6 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
             displayNames: setupSqlCommand.bind(null, sql.getAppDisplayNames(appObj.id)),
             moduleNames: setupSqlCommand.bind(null, sql.getAppModules(appObj.id)),
             funcGroupNames: setupSqlCommand.bind(null, sql.getAppFunctionalGroups(isProduction, appObj)),
-            blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps()),
         }, {method: 'parallel'});
 
         flame.flow([
@@ -133,7 +132,8 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
         },
         defaultFuncGroups: setupSqlCommand.bind(null, sql.getDefaultFunctionalGroups(isProduction)),
         preDataConsentFuncGroups: setupSqlCommand.bind(null, sql.getPreDataConsentFunctionalGroups(isProduction)),
-        deviceFuncGroups: setupSqlCommand.bind(null, sql.getDeviceFunctionalGroups(isProduction))
+        deviceFuncGroups: setupSqlCommand.bind(null, sql.getDeviceFunctionalGroups(isProduction)),
+        blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps())
     }, {method: 'parallel'});
     flame.flow([
         getAllDataFlow,

--- a/app/v1/policy/helper.js
+++ b/app/v1/policy/helper.js
@@ -4,6 +4,7 @@ const flame = app.locals.flame;
 const model = require('./model.js');
 const setupSqlCommand = app.locals.db.setupSqlCommand;
 const sql = require('./sql.js');
+const sqlApps = require('../applications/sql.js');
 const funcGroupSql = require('../groups/sql.js');
 const messagesSql = require('../messages/sql.js');
 const moduleConfigSql = require('../module-config/sql.js');
@@ -100,7 +101,7 @@ function setupAppPolicies (isProduction, reqAppPolicy) {
     let getAppPolicy = [];
     if (uuids.length) {
         getAppPolicy.push(setupSqlCommand.bind(null, sql.getBaseAppInfo(isProduction, uuids)));
-    } 
+    }
     else {
         getAppPolicy.push(function (callback) {
             callback(null, []);
@@ -116,6 +117,7 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
             displayNames: setupSqlCommand.bind(null, sql.getAppDisplayNames(appObj.id)),
             moduleNames: setupSqlCommand.bind(null, sql.getAppModules(appObj.id)),
             funcGroupNames: setupSqlCommand.bind(null, sql.getAppFunctionalGroups(isProduction, appObj)),
+            blacklistedApps: setupSqlCommand.bind(null, sqlApps.getBlacklistedApps()),
         }, {method: 'parallel'});
 
         flame.flow([
@@ -133,7 +135,6 @@ function mapAppBaseInfo (isProduction, requestedUuids, appObjs, callback) {
         preDataConsentFuncGroups: setupSqlCommand.bind(null, sql.getPreDataConsentFunctionalGroups(isProduction)),
         deviceFuncGroups: setupSqlCommand.bind(null, sql.getDeviceFunctionalGroups(isProduction))
     }, {method: 'parallel'});
-
     flame.flow([
         getAllDataFlow,
         model.aggregateResults

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -1,6 +1,7 @@
 const app = require('../app');
 const flame = app.locals.flame;
 const settings = require('../../../settings.js');
+const sqlApp = require('../applications/sql.js');
 
 //module config
 
@@ -217,8 +218,16 @@ function constructAppPolicy (appObj, res, next) {
     const funcGroupNames = res.funcGroupNames.map(function (elem) {
         return elem.property_name;
     });
+    const blacklistedApps = res.blacklistedApps;
 
     const appPolicyObj = {};
+    for (let i = 0; i < blacklistedApps.length; i++) {
+        if (blacklistedApps[i].app_uuid === appObj.app_uuid) {
+            appPolicyObj[appObj.app_uuid] = null;
+            next(null, appPolicyObj);
+            return;
+        }
+    }
     appPolicyObj[appObj.app_uuid] = {
         nicknames: displayNames,
         keep_context: true,
@@ -228,7 +237,6 @@ function constructAppPolicy (appObj, res, next) {
         groups: funcGroupNames,
         moduleType: moduleNames
     };
-
     next(null, appPolicyObj);
 }
 

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -218,16 +218,8 @@ function constructAppPolicy (appObj, res, next) {
     const funcGroupNames = res.funcGroupNames.map(function (elem) {
         return elem.property_name;
     });
-    const blacklistedApps = res.blacklistedApps;
 
     const appPolicyObj = {};
-    for (let i = 0; i < blacklistedApps.length; i++) {
-        if (blacklistedApps[i].app_uuid === appObj.app_uuid) {
-            appPolicyObj[appObj.app_uuid] = null;
-            next(null, appPolicyObj);
-            return;
-        }
-    }
     appPolicyObj[appObj.app_uuid] = {
         nicknames: displayNames,
         keep_context: true,
@@ -251,6 +243,7 @@ function aggregateResults (res, next) {
     const deviceFuncGroups = res.deviceFuncGroups.map(function (obj) {
         return obj.property_name;
     });
+    const blacklistedApps = res.blacklistedApps;
 
     const appPolicy = {};
 
@@ -263,6 +256,11 @@ function aggregateResults (res, next) {
     for (let i = 0; i < policyObjs.length; i++) {
         const key = Object.keys(policyObjs[i])[0];
         appPolicy[key] = policyObjs[i][key];
+    }
+
+    // Set app policy object to null if it is blacklisted
+    for (let i = 0; i < blacklistedApps.length; i++) {
+        appPolicy[blacklistedApps[i].app_uuid] = null;
     }
 
     //setup defaults after the app ids are populated

--- a/migrations/20180424123545-app-blacklist.js
+++ b/migrations/20180424123545-app-blacklist.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180424123545-app-blacklist-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180424123545-app-blacklist-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180424123545-app-blacklist-down.sql
+++ b/migrations/sqls/20180424123545-app-blacklist-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS app_blacklist;

--- a/migrations/sqls/20180424123545-app-blacklist-up.sql
+++ b/migrations/sqls/20180424123545-app-blacklist-up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE app_blacklist (
+    "app_uuid" VARCHAR(36),
+    "created_ts" TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (app_uuid)
+)
+WITH ( OIDS = FALSE );

--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -82,7 +82,7 @@
                             </tbody>
                         </table>
                     </div>
-                    <div>
+                    <div v-if="app.approval_status !== 'DENIED'">
                         <label class="switch">
                             <input v-on:click="autoApproveClick" v-model="app.is_auto_approved_enabled" type="checkbox"></input>
                             <span class="slider round"></span>
@@ -194,6 +194,22 @@
                             v-bind:loading="no_feedback_button_loading">
                             Send without feedback
                         </vue-ladda>
+                        <div class="horizontal-divider">
+                            <span class="line"></span>
+                            <span class="text">OR</span>
+                            <span class="line"></span>
+                        </div>
+                        <vue-ladda
+                            type="button"
+                            v-on:click="sendBlacklistClick()"
+                            class="btn btn-card btn-style-black"
+                            data-style="zoom-in"
+                            v-bind:loading="blacklist_button_loading">
+                            Blacklist Application
+                        </vue-ladda>
+                        <br>
+                        <br>
+                        <h4>Note: Blacklisting an application will deny it from receiving any permissions in both staging and production</h4>
                     </form>
                 </b-modal>
 
@@ -215,6 +231,7 @@ export default {
             "button_loading": false,
             "send_button_loading": false,
             "no_feedback_button_loading": false,
+            "blacklist_button_loading": false,
             "app": null,
             "policytable": null
         };
@@ -229,7 +246,9 @@ export default {
             this.httpRequest("post", "applications/action", {
                 "body": {
                     "id": this.$route.params.id,
-                    "approval_status": "ACCEPTED"
+                    "approval_status": "ACCEPTED",
+                    "blacklist": false,
+                    "uuid": this.app.uuid
                 }
             }, (err, response) => {
                 if(err){
@@ -297,6 +316,24 @@ export default {
                     this.actions_visible = false;
                     this.$refs.appActionModal.hide();
                 }
+            });
+        },
+        "sendBlacklistClick": function() {
+            this.blacklist_button_loading = true;
+            this.httpRequest("post", "applications/action", {
+                "body": {
+                    "id": this.$route.params.id,
+                    "approval_status": "DENIED",
+                    "blacklist": true,
+                    "uuid": this.app.uuid
+                }
+            }, (err, response) => {
+                if (!err) {
+                    this.app.approval_status = "DENIED";
+                    this.$refs.appActionModal.hide();
+                }
+                this.actions_visible = false;
+                this.blacklist_button_loading = false;
             });
         },
         getPolicy: function(){

--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -209,7 +209,7 @@
                         </vue-ladda>
                         <br>
                         <br>
-                        <h4>Note: Blacklisting an application will deny it from receiving any permissions in both staging and production</h4>
+                        <h4>Note: Blacklisting an application will deny any version of it from receiving any permissions in both staging and production</h4>
                     </form>
                 </b-modal>
 

--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -20,7 +20,8 @@
                         <b-btn v-b-modal.appActionModal class="btn btn-danger btn-sm align-middle">Deny</b-btn>
                     </template>
                     <template v-else-if="actions_visible">
-                        <span class="app-status align-middle"><i class="fa fa-fw fa-circle" v-bind:class="classStatusDot"></i> {{ app.approval_status }}</span>
+                        <span v-if="app.is_blacklisted" class="app-status align-middle"><i class="fa fa-fw fa-circle" style="color: black;"></i> BLACKLISTED</span>
+                        <span v-else class="app-status align-middle"><i class="fa fa-fw fa-circle" v-bind:class="classStatusDot"></i> {{ app.approval_status }}</span>
                         <vue-ladda
                             v-if="app.approval_status == 'DENIED'"
                             type="button"
@@ -34,7 +35,8 @@
                         <a v-on:click="toggleActions" class="fa fa-fw fa-1-5x fa-times align-middle"></a>
                     </template>
                     <template v-else>
-                        <span class="app-status align-middle"><i class="fa fa-fw fa-circle" v-bind:class="classStatusDot"></i> {{ app.approval_status }}</span>
+                        <span v-if="app.is_blacklisted" class="app-status align-middle"><i class="fa fa-fw fa-circle" style="color: black;"></i> BLACKLISTED</span>
+                        <span v-else class="app-status align-middle"><i class="fa fa-fw fa-circle" v-bind:class="classStatusDot"></i> {{ app.approval_status }}</span>
                         <a v-on:click="toggleActions" class="fa fa-fw fa-1-5x fa-ellipsis-v align-middle"></a>
                     </template>
                 </div>
@@ -260,6 +262,7 @@ export default {
                     // success
                     console.log("done");
                     this.app.approval_status = "ACCEPTED";
+                    this.app.is_blacklisted = false;
                     this.button_loading = false;
                     this.actions_visible = false;
                 }
@@ -330,6 +333,7 @@ export default {
             }, (err, response) => {
                 if (!err) {
                     this.app.approval_status = "DENIED";
+                    this.app.is_blacklisted = true;
                     this.$refs.appActionModal.hide();
                 }
                 this.actions_visible = false;
@@ -356,8 +360,10 @@ export default {
                     console.log("policy table retrieved");
                     console.log(response);
                     response.json().then(parsed => {
-                        if(parsed.data && parsed.data.length && parsed.data[0].policy_table.app_policies[this.app.uuid]){
-                            this.policytable = parsed.data[0].policy_table.app_policies[this.app.uuid];
+                        if(parsed.data && parsed.data.length ) {
+                            var appObject = {};
+                            appObject[this.app.uuid] = parsed.data[0].policy_table.app_policies[this.app.uuid];
+                            this.policytable = appObject;
                         }else{
                             console.log("No policy table returned");
                         }


### PR DESCRIPTION
Fixes #65 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* Blacklisting an application is successful when done through the deny modal dialog on the application's details screen.
* UI on a blacklisted application's details screens reflects its state at the top of the page (Blacklisted indicator) and in its policy table preview (uuid object set to null). Auto approve updates toggle should also be hidden for a blacklisted app.
* New versions of an application should be denied if it is blacklisted.

### Summary
Policy server users will be able to blacklist applications. Blacklisted applications will not be able to receive any permissions for SDL usage. In addition, any future versions of a blacklisted app with automatically be denied.

##### Enhancements
* Blacklist option now available when denying an application.
* UI shows indicators for a blacklisted application.
* New versions of blacklisted applications are automatically denied.