### PR TITLE
Fix flipped environment values for policy table, functional groups, c…

### DIFF
--- a/src/components/ConsumerMessages.vue
+++ b/src/components/ConsumerMessages.vue
@@ -142,9 +142,11 @@
                 });
             },
             "environmentClick": function () {
-                //get high level message data
-                this.getConsumerMessageInfo(messages => {
-                    this.consumer_messages = messages;
+                this.$nextTick(function () {
+                    //get high level message data
+                    this.getConsumerMessageInfo(messages => {
+                        this.consumer_messages = messages;
+                    });
                 });
             }
         },

--- a/src/components/FunctionalGroups.vue
+++ b/src/components/FunctionalGroups.vue
@@ -200,11 +200,13 @@
         },
         methods: {
             "environmentClick": function () {
-                this.functional_groups = [];
-                //get high level functional group data
-                this.getFunctionalGroupData();
-                //get unmapped permissions
-                this.getUnmappedPermissions();
+                this.$nextTick(function () {
+                    this.functional_groups = [];
+                    //get high level functional group data
+                    this.getFunctionalGroupData();
+                    //get unmapped permissions
+                    this.getUnmappedPermissions();
+                });
             },
             "getFunctionalGroupData": function () {
                 this.httpRequest("get", "groups", {

--- a/src/components/ModuleConfig.vue
+++ b/src/components/ModuleConfig.vue
@@ -214,25 +214,27 @@
                 this.$scrollTo("body", 500);
             },
             "environmentClick": function () {
-                this.httpRequest("get", "module", {
-                    "params": {
-                        "environment": this.environment
-                    }
-                }, (err, res) => {
-                    if (err) {
-                        console.log("Error fetching module config data: ");
-                        console.log(err);
-                    }
-                    else {
-                        res.json().then(parsed => {
-                            if (parsed.data.module_configs && parsed.data.module_configs.length) {
-                                this.module_config = parsed.data.module_configs[0]; //only one entry
-                            }
-                            else {
-                                console.log("No module config data returned");
-                            }
-                        });
-                    }
+                this.$nextTick(function () {
+                    this.httpRequest("get", "module", {
+                        "params": {
+                            "environment": this.environment
+                        }
+                    }, (err, res) => {
+                        if (err) {
+                            console.log("Error fetching module config data: ");
+                            console.log(err);
+                        }
+                        else {
+                            res.json().then(parsed => {
+                                if (parsed.data.module_configs && parsed.data.module_configs.length) {
+                                    this.module_config = parsed.data.module_configs[0]; //only one entry
+                                }
+                                else {
+                                    console.log("No module config data returned");
+                                }
+                            });
+                        }
+                    });
                 });
             },
             "saveModuleConfig": function () {

--- a/src/components/PolicyTable.vue
+++ b/src/components/PolicyTable.vue
@@ -59,26 +59,28 @@ export default {
     },
     methods: {
         "environmentClick": function(){
-            const self = this;
-            console.log("Selected environment: " + this.environment);
-            this.httpRequest("get", "policy/preview", {
-                "params": {
-                    "environment": this.environment
-                }
-            }, (err, response) => {
-                if (err) {
-                    console.log("Error fetching policy table.");
-                    console.log(err);
-                } else {
-                    console.log("policy table retrieved");
-                    response.json().then(parsed => {
-                        if(parsed.data && parsed.data.length){
-                            this.policytable = parsed.data[0];
-                        }else{
-                            console.log("No policy table returned");
-                        }
-                    });
-                }
+            this.$nextTick(function () {
+                const self = this;
+                console.log("Selected environment: " + this.environment);
+                this.httpRequest("get", "policy/preview", {
+                    "params": {
+                        "environment": this.environment
+                    }
+                }, (err, response) => {
+                    if (err) {
+                        console.log("Error fetching policy table.");
+                        console.log(err);
+                    } else {
+                        console.log("policy table retrieved");
+                        response.json().then(parsed => {
+                            if(parsed.data && parsed.data.length){
+                                this.policytable = parsed.data[0];
+                            }else{
+                                console.log("No policy table returned");
+                            }
+                        });
+                    }
+                });
             });
         },
     },


### PR DESCRIPTION
…onsumer messages, and module config pages.

Fixes #74 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Toggle Staging/Production environment on the following pages when using Chrome, Firefox, and Safari:  
* /policytable
* /functionalgroups
* /consumermessages
* /moduleconfig

### Summary
Staging and Production values are not flipped when viewing the above pages in Firefox and Safari.