### PR TITLE
Fix server crash when a GET request is sent to /messages with an inva…

### DIFF
--- a/app/v1/messages/model.js
+++ b/app/v1/messages/model.js
@@ -153,6 +153,10 @@ function transformMessages (info, next) {
         return elem.property_name
     });
 
+    if (!group) {
+        return next(null, []);
+    }
+
     template = hashifyTemplate(template);
 
     //fill out the base object first


### PR DESCRIPTION
…lid id.

Fixes #76 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send a GET request to /messages with an invalid id as a query parameter.

##### Bug Fixes
* Server no longer crashes when sending an invalid id to the /messages endpoint