### PR TITLE
Fix server crash when sending a POST request to /messages/update.

### DIFF
--- a/app/v1/app.js
+++ b/app/v1/app.js
@@ -66,7 +66,7 @@ function exposeRoutes () {
 	app.get('/messages/names', auth.validateAuth, messages.getNames);
 	app.post('/messages', auth.validateAuth, messages.postAddMessage);
 	app.post('/messages/promote', auth.validateAuth, messages.postPromoteMessages);
-	app.post('/messages/update', auth.validateAuth, messages.updateLanguages);
+	app.post('/messages/update', auth.validateAuth, messages.postUpdate);
 	app.get('/module', auth.validateAuth, moduleConfig.get);
 	app.post('/module', auth.validateAuth, moduleConfig.post);
 	app.post('/module/promote', auth.validateAuth, moduleConfig.promote);


### PR DESCRIPTION
Fixes #77 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send a POST request to the /messages/update endpoint.

##### Bug Fixes
* Server no longer crashes when sending a POST request to /messages/update