### PR TITLE
Add UI changes based on 2.4.0 review.

### DIFF
--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -11,8 +11,8 @@
                 -->
                 <div class="app-action pull-right">
                     <b-dropdown right
-                        id="ddown-right" 
-                        :text="selected_option.state" 
+                        id="ddown-right"
+                        :text="selected_option.state"
                         :class="selected_option.class">
                         <div
                             v-for="opt in dropdown_options[selected_option.id]"
@@ -28,13 +28,13 @@
                             <b-dropdown-divider
                                 v-if="opt === 'divide'">
                             </b-dropdown-divider>
-                            
+
                         </div>
                     </b-dropdown>
                 </div>
 
                 <div class="app-table">
-                    <h4>General App Info<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/applications/"></a></h4>
+                    <h4>General App Info<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/applications/" target="_blank"></a></h4>
                     <div class="table-responsive">
                         <table class="table table-striped">
                             <thead>
@@ -181,7 +181,7 @@
                         <h6>Rejecting an application will disallow any changes the application requested, including additional permissions. <br><br>
                             However, permissions received from the previously accepted version and from default functional groups will still be given.</h6>
                         <div class="form-group">
-                            <textarea v-model="app.denial_message" class="app-action form-control" id="appActionReason" rows="5" placeholder="Reason here..."></textarea>
+                            <textarea v-model="modal_text" class="app-action form-control" id="appActionReason" rows="5" placeholder="Reason here..."></textarea>
                         </div>
                         <vue-ladda
                             type="button"
@@ -199,7 +199,7 @@
                     <form>
                         <h6>Blacklisting an application will prevent it from receiving any permissions on both staging and production.</h6>
                         <div class="form-group">
-                            <textarea v-model="app.denial_message" class="app-action form-control" id="appActionReason" rows="5" placeholder="Reason here..."></textarea>
+                            <textarea v-model="modal_text" class="app-action form-control" id="appActionReason" rows="5" placeholder="Reason here..."></textarea>
                         </div>
                         <vue-ladda
                             type="button"
@@ -330,6 +330,7 @@ export default {
             "selected_option": pending_opt,
             "immediate_option_clicked": {},
             "blacklist_toggle": false,
+            "modal_text": "",
         };
     },
     methods: {
@@ -382,7 +383,7 @@ export default {
                     "approval_status": approvalStatus,
                     "blacklist": isBlacklisted,
                     "uuid": this.app.uuid,
-                    "denial_message": withFeedBack ? this.app.denial_message : null
+                    "denial_message": withFeedBack ? this.modal_text : null
                 }
             }, (err, response) => {
                 this.$refs.appActionModal.hide();
@@ -480,7 +481,7 @@ export default {
                         }
                     });
                 }
-            });            
+            });
         }
     },
     computed: {
@@ -500,7 +501,7 @@ export default {
             }
         },
         contains_feedback: function () {
-            return this.app && this.app.denial_message;
+            return this.app && this.modal_text;
         }
     },
     created: function(){

--- a/src/components/Applications.vue
+++ b/src/components/Applications.vue
@@ -9,7 +9,7 @@
 
                 <div v-for="appList in apps">
                     <div class="app-table" v-if="appList.list.length > 0">
-                        <h4 :class="appList.class">{{ appList.title }}<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/applications/"></a></h4>
+                        <h4 :class="appList.class">{{ appList.title }}<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/applications/" target="_blank"></a></h4>
                         <div class="table-responsive">
                             <table class="table table-striped">
                                 <thead>
@@ -51,13 +51,13 @@
                     "apps_approved": {
                         "list": [],
                         "class": "color-green",
-                        "title": "Approved Applications"
+                        "title": "Accepted Applications"
                     },
                     "apps_denied": {
                         "list": [],
                         "class": "color-red",
                         "title": "Limited Applications"
-                    },                   
+                    },
                 }
             }
         },

--- a/src/components/ConsumerMessageDetails.vue
+++ b/src/components/ConsumerMessageDetails.vue
@@ -15,13 +15,13 @@
                 </div>
 
                 <div class="functional-content">
-                    <h4>Consumer Message {{ message.is_deleted ? "(deleted)" : "" }} <a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/"></a></h4>
+                    <h4>Consumer Message {{ message.is_deleted ? "(deleted)" : "" }} <a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/" target="_blank"></a></h4>
 
                     <!-- Name -->
                     <div class="form-row">
                         <h4 for="name">Name</h4>
                         <input v-model="message.message_category" :disabled="id" type="email" class="form-control" id="email">
-                        <p v-if="duplicateName"><br>A consumer message with this name already exists! By saving, you will overwrite the previously existing consumer message.</p>
+                        <p v-if="duplicateName && !id"><br>A consumer message with this name already exists! By saving, you will overwrite the previously existing consumer message.</p>
                     </div>
 
                     <!-- container for languages -->
@@ -69,7 +69,7 @@
                         v-if="isLangAvailable(value)"
                         v-on:click="addLanguage(value)"
                     >
-                    {{ value.language_id }}<i v-b-tooltip.hover.auto title="" class="fa fa-info-circle pull-right"></i>
+                    {{ value.language_id }}
                     </li>
                 </ul>
             </b-modal>

--- a/src/components/ConsumerMessages.vue
+++ b/src/components/ConsumerMessages.vue
@@ -18,7 +18,7 @@
                     <b-btn v-if="environment == 'STAGING' && can_promote" v-b-modal.promoteModal class="btn btn-style-green btn-sm align-middle">Promote changes to production</b-btn>
                 </div>
 
-                <h4>Consumer Friendly Messages<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/"></a></h4>
+                <h4>Consumer Friendly Messages<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/" target="_blank"></a></h4>
                 <section class="tiles">
                     <card-item
                         v-for="(item, index) in consumer_messages"

--- a/src/components/FunctionalGroupDetails.vue
+++ b/src/components/FunctionalGroupDetails.vue
@@ -15,13 +15,13 @@
                 </div>
 
                 <div class="functional-content">
-                    <h4>Functional Group <a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/"></a></h4>
+                    <h4>Functional Group <a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/" target="_blank"></a></h4>
 
                     <!-- Name -->
                     <div class="form-row">
                         <h4 for="name">Name</h4>
                         <input v-model="fg.name" :disabled="id" type="email" class="form-control" id="email" required>
-                        <p v-if="duplicateName"><br>A functional group with this name already exists! By saving, you will overwrite the previously existing functional group.</p>
+                        <p v-if="duplicateName && !id"><br>A functional group with this name already exists! By saving, you will overwrite the previously existing functional group.</p>
                     </div>
 
                     <!-- Description -->
@@ -115,7 +115,7 @@
                             v-if="isRpcAvailable(item)"
                             v-on:click="addRpc(item)"
                         >
-                        {{ item.name }}<i v-b-tooltip.hover.auto title="" class="fa fa-info-circle pull-right"></i>
+                        {{ item.name }}
                         </li>
                     </ul>
                 </b-modal>

--- a/src/components/FunctionalGroups.vue
+++ b/src/components/FunctionalGroups.vue
@@ -24,7 +24,7 @@
                         {{ perm.name }} ({{ perm.type }})
                     </div>
                 </div>
-                <h4>Functional Groups<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/"></a></h4>
+                <h4>Functional Groups<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/messages-and-functional-groups/" target="_blank"></a></h4>
                 <section class="tiles">
                     <card-item
                         v-for="(item, index) in functional_groups"

--- a/src/components/ModuleConfig.vue
+++ b/src/components/ModuleConfig.vue
@@ -19,7 +19,7 @@
                     <b-btn v-if="environment == 'STAGING' && canPromote" v-b-modal.promoteModal class="btn btn-style-green btn-sm align-middle">Promote changes to production</b-btn>
                 </div>
 
-                <h4>Module Config<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/module-config/"></a></h4>
+                <h4>Module Config<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/module-config/" target="_blank"></a></h4>
 
                 <!-- module config data -->
                 <div class="functional-content" v-if="module_config">
@@ -122,7 +122,7 @@
                                         <input v-model="module_config.endpoints['lock_screen_icon_url']" :disabled="fieldsDisabled" class="form-control"></input>
                                     </div>
                                     <div class="col-sm">
-                                        <img v-if="module_config.endpoints['lock_screen_icon_url']" v-bind:src="module_config.endpoints['lock_screen_icon_url']" class="pull-right" style="max-width:50px;max-height:50px;"/>
+                                        <img v-if="module_config.endpoints['lock_screen_icon_url']" v-bind:src="module_config.endpoints['lock_screen_icon_url']" class="pull-right" style="max-width:90px;max-height:50px;"/>
                                     </div>
                                 </div>
 

--- a/src/components/PolicyTable.vue
+++ b/src/components/PolicyTable.vue
@@ -14,14 +14,14 @@
                     :options="environmentOptions"
                     name="chooseEnvironment" />
 
-                <h4>Policy Table<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/view-policy-table/"></a></h4>
+                <h4>Policy Table<a class="fa fa-question-circle color-primary doc-link" v-b-tooltip.hover title="Click here for more info about this page" href="https://smartdevicelink.com/en/guides/sdl-server/user-interface/view-policy-table/" target="_blank"></a></h4>
                 <b-input-group style="margin-bottom:0.5em;">
                     <b-input-group-addon>POST</b-input-group-addon>
                     <b-form-input type="text" v-bind:value="policyTablePostUrl"></b-form-input>
                 </b-input-group>
                 <div v-if="policytable !== null">
                     <vue-json-pretty :data="policytable"></vue-json-pretty>
-                    <a id="back-to-top" v-scroll-to="'body'" v-on:click.prevent class="btn btn-primary btn-lg back-to-top" role="button"><i class="fa fa-fw fa-chevron-up"></i></a>
+                    <a v-if="!at_top" id="back-to-top" v-scroll-to="'body'" v-on:click.prevent class="btn btn-primary btn-lg back-to-top" role="button"><i class="fa fa-fw fa-chevron-up"></i></a>
                 </div>
             </main>
         </div>
@@ -49,7 +49,8 @@ export default {
                     "value": "production"
                 }
             ],
-            "policytable": null
+            "policytable": null,
+            "at_top": true
         };
     },
     computed: {
@@ -81,11 +82,18 @@ export default {
                 }
             });
         },
+        "checkScroll": function(e) {
+            this.at_top = window.scrollY ? false : true;
+        }
     },
     created: function(){
+        window.addEventListener('scroll', this.checkScroll);
     },
     mounted: function(){
         this.environmentClick();
+    },
+    destroyed: function() {
+        window.removeEventListener('scroll', this.checkScroll);
     }
 }
 </script>


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Visual test for each instance below

### Summary
* All pages
  * Question mark icons open links in new tabs
* Applications page
  * 'Approved' heading changed to 'Accepted'
* Applications details page
  * Text in blacklist modal popup no longer linked to decline notes on page. Also does not persist when just closing the modal
* Policy table page
  * Back to top button no longer shows when at the top of the page
* Functional group details page
  * Name already exists message will only show when creating a new group
  * Removed info icons for RPC selection items
* Consumer message details page
  * Name already exists message will only show when creating a new message
  * Removed info icons for language selection items
* Module config page
  * Set max-width of lock screen image preview to fit the size of the div (90px)