### PR TITLE
Invalid uuids are no longer added to the auto approve table.

### DIFF
--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -301,13 +301,23 @@ function insertAppAutoApproval (obj) {
             `'${obj.uuid}' AS app_uuid`
             )
         .where(
-            sql.not(
+            sql.and(
+                sql.not(
+                    sql.exists(
+                        sql.select('*')
+                            .from('app_auto_approval aaa')
+                            .where({
+                                'aaa.app_uuid': obj.uuid
+                            })
+                    )
+                ),
                 sql.exists(
                     sql.select('*')
-                        .from('app_auto_approval aaa')
+                        .from('app_info')
                         .where({
-                            'aaa.app_uuid': obj.uuid
+                            'app_uuid': obj.uuid
                         })
+                        .limit(1)
                 )
             )
         )


### PR DESCRIPTION
Fixes #75 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send a POST request to /applications/auto with a body containing an invalid uuid and is_auto_approved_enabled set to true. Check the auto approve table to make sure the invalid uuid is not added to the table.

##### Bug Fixes
* Invalid uuids are no longer added to the auto approve table