### PR TITLE
#95 Hotfix: Short App IDs

### DIFF
--- a/app/v1/applications/model.js
+++ b/app/v1/applications/model.js
@@ -36,6 +36,7 @@ function constructFullAppObjs (res, next) {
     for (let i = 0; i < appBase.length; i++) {
         hashedApps[appBase[i].id] = appBase[i];
         hashedApps[appBase[i].id].uuid = hashedApps[appBase[i].id].app_uuid;
+        hashedApps[appBase[i].id].short_uuid = hashedApps[appBase[i].id].app_short_uuid;
         hashedApps[appBase[i].id].category = {
             id: appBase[i].category_id,
             display_name: hashedCategories[appBase[i].category_id]
@@ -54,6 +55,8 @@ function constructFullAppObjs (res, next) {
         }
 
         delete hashedApps[appBase[i].id].app_uuid;
+        delete hashedApps[appBase[i].id].app_short_uuid;
+
         hashedApps[appBase[i].id].countries = [];
         hashedApps[appBase[i].id].display_names = [];
         hashedApps[appBase[i].id].permissions = [];

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -230,6 +230,7 @@ function insertVendor (obj) {
 function insertAppInfo (obj) {
     let insertObj = {
         app_uuid: obj.uuid,
+        app_short_uuid: obj.short_uuid,
         name: obj.name,
         platform: obj.platform,
         platform_app_id: obj.platform_app_id,
@@ -373,11 +374,24 @@ function getAppBlacklist (id) {
         .toString();
 }
 
-function getBlacklistedApps (uuids) {
-    return sql.select('app_uuid')
-            .from('app_blacklist')
-            .where(sql.in('app_uuid', uuids))
-            .toString();
+function getBlacklistedApps (uuids, useLongUuids = false) {
+    var query = sql.select('app_info.app_uuid, app_info.app_short_uuid')
+        .from('app_info')
+        .join('app_blacklist', {
+            "app_blacklist.app_uuid": 'app_info.app_uuid'
+        });
+
+    if(useLongUuids){
+        query.where(
+            sql.in('app_info.app_uuid', uuids)
+        );
+    }else{
+        query.where(
+            sql.in('app_info.app_short_uuid', uuids)
+        );
+    }
+
+    return query.toString();
 }
 
 module.exports = {

--- a/app/v1/helpers/parcel.js
+++ b/app/v1/helpers/parcel.js
@@ -61,7 +61,7 @@ class Parcel {
     // method to write the response to the client
     deliver(){
         var response_ts = new Date();
-        if(this.res && this.res.app.locals.log) this.res.app.locals.log.info(this.getJSON());
+        if(this.res && this.res.app.locals.log) this.res.app.locals.log.info(JSON.stringify(this.getJSON()));
 
         // send response to client
         this.res

--- a/app/v1/module-config/helper.js
+++ b/app/v1/module-config/helper.js
@@ -15,9 +15,6 @@ function validatePost (req, res) {
     req.body.exchange_after_x_days -= 0;
     req.body.timeout_after_x_seconds -= 0;
 
-    if (!check.boolean(req.body.preloaded_pt)) {
-        return setError("preloaded_pt required");
-    }
     if (!check.number(req.body.exchange_after_x_ignition_cycles)) {
         return setError("exchange_after_x_ignition_cycles required");
     }

--- a/app/v1/module-config/model.js
+++ b/app/v1/module-config/model.js
@@ -36,7 +36,6 @@ function baseTemplate (objOverride) {
     const obj = {
         id: 0,
         status: "PRODUCTION",
-        preloaded_pt: true,
         exchange_after_x_ignition_cycles: 0,
         exchange_after_x_kilometers: 0,
         exchange_after_x_days: 0,
@@ -61,7 +60,6 @@ function baseTemplate (objOverride) {
         //add overrides to the default
         obj.id = objOverride.id;
         obj.status = objOverride.status;
-        obj.preloaded_pt = objOverride.preloaded_pt;
         obj.exchange_after_x_ignition_cycles = objOverride.exchange_after_x_ignition_cycles;
         obj.exchange_after_x_kilometers = objOverride.exchange_after_x_kilometers;
         obj.exchange_after_x_days = objOverride.exchange_after_x_days;

--- a/app/v1/module-config/sql.js
+++ b/app/v1/module-config/sql.js
@@ -30,7 +30,6 @@ function retrySecondsByStatus (isProduction) {
 function insertModuleConfig (moduleConfig) {
     return sql.insert('module_config', {
         status: moduleConfig.status,
-        preloaded_pt: moduleConfig.preloaded_pt,
         exchange_after_x_ignition_cycles: moduleConfig.exchange_after_x_ignition_cycles,
         exchange_after_x_kilometers: moduleConfig.exchange_after_x_kilometers,
         exchange_after_x_days: moduleConfig.exchange_after_x_days,

--- a/app/v1/policy/controller.js
+++ b/app/v1/policy/controller.js
@@ -2,6 +2,7 @@
 const app = require('../app');
 const helper = require('./helper.js');
 const encryption = require('../../../customizable/encryption');
+const GET = require('lodash.get');
 
 function postFromCore (isProduction) {
 	return function (req, res, next) {
@@ -14,22 +15,24 @@ function postFromCore (isProduction) {
 		if (res.errorMsg) {
 			return res.status(400).send({ error: res.errorMsg });
 		}
-        helper.generatePolicyTable(isProduction, req.body.policy_table.app_policies, true, handlePolicyTableFlow.bind(null, res, true));
+		const useLongUuids = GET(req, "body.policy_table.module_config.full_app_id_supported", false) ? true : false;
+        helper.generatePolicyTable(isProduction, useLongUuids, req.body.policy_table.app_policies, true, handlePolicyTableFlow.bind(null, res, true));
 	}
 }
 
 function getPreview (req, res, next) {
     const isProduction = !req.query.environment || req.query.environment.toLowerCase() !== 'staging';
-    helper.generatePolicyTable(isProduction, {}, true, handlePolicyTableFlow.bind(null, res, false));
+    helper.generatePolicyTable(isProduction, false, {}, true, handlePolicyTableFlow.bind(null, res, false));
 }
 
 function postAppPolicy (req, res, next) {
     const isProduction = !req.query.environment || req.query.environment.toLowerCase() !== 'staging';
+	const useLongUuids = GET(req, "body.policy_table.module_config.full_app_id_supported", false) ? true : false;
     helper.validateAppPolicyOnlyPost(req, res);
     if (res.errorMsg) {
         return res.status(400).send({ error: res.errorMsg });
     }
-    helper.generatePolicyTable(isProduction, req.body.policy_table.app_policies, false, handlePolicyTableFlow.bind(null, res, false));
+    helper.generatePolicyTable(isProduction, useLongUuids, req.body.policy_table.app_policies, false, handlePolicyTableFlow.bind(null, res, false));
 }
 
 function handlePolicyTableFlow (res, encrypt = false, err, pieces) {

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -25,7 +25,6 @@ function transformModuleConfig (isProduction, useLongUuids = false, info, next) 
     }
 
     next(null, {
-        "preloaded_pt": base.preloaded_pt,
         "full_app_id_supported": useLongUuids,
         "exchange_after_x_ignition_cycles": base.exchange_after_x_ignition_cycles,
         "exchange_after_x_kilometers": base.exchange_after_x_kilometers,

--- a/app/v1/policy/sql.js
+++ b/app/v1/policy/sql.js
@@ -1,7 +1,7 @@
 const sql = require('sql-bricks-postgres');
 const funcGroupSql = require('../groups/sql.js');
 
-function getBaseAppInfo (isProduction, appUuids) {
+function getBaseAppInfo (isProduction, useLongUuids = false, appUuids) {
     let approvalStatusArray = [];
     if (isProduction) {
         approvalStatusArray = ["ACCEPTED"];
@@ -14,10 +14,17 @@ function getBaseAppInfo (isProduction, appUuids) {
         .from('view_partial_app_info')
         .where(
             sql.in('approval_status', approvalStatusArray)
-        )
-        .where(
+        );
+    if(useLongUuids){
+        innerSelect.where(
             sql.in('app_uuid', appUuids)
         );
+    }else{
+        innerSelect.where(
+            sql.in('app_short_uuid', appUuids)
+        );
+    }
+
 
     const whereIn = sql.select('max(id) AS id')
         .from('(' + innerSelect + ') AS test')

--- a/migrations/20180530184543-short-app-uuids.js
+++ b/migrations/20180530184543-short-app-uuids.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180530184543-short-app-uuids-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180530184543-short-app-uuids-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180530184543-short-app-uuids-down.sql
+++ b/migrations/sqls/20180530184543-short-app-uuids-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.app_info
+DROP COLUMN IF EXISTS app_short_uuid;

--- a/migrations/sqls/20180530184543-short-app-uuids-up.sql
+++ b/migrations/sqls/20180530184543-short-app-uuids-up.sql
@@ -1,0 +1,11 @@
+-- add a short_uuid column to applications
+ALTER TABLE public.app_info
+ADD COLUMN IF NOT EXISTS app_short_uuid VARCHAR(10);
+
+-- populate the new short_uuid column for existing applications
+UPDATE public.app_info
+SET app_short_uuid = substring(regexp_replace(app_uuid, '(-|_)', '') from 1 for 10);
+
+-- make sure the new short_uuid column is never NULL
+ALTER TABLE public.app_info
+ALTER COLUMN app_short_uuid SET NOT NULL;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl_policy_server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "BSD-3-Clause",
   "description": "Integrates with SHAID to allow managing app permissions through policy tables",
   "author": "Livio",

--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -428,6 +428,9 @@ export default {
             this.httpRequest("post", "policy/apps?environment=" + envName, {
                 "body": {
                     "policy_table": {
+                        "module_config": {
+                            "full_app_id_supported": true
+                        },
                         "app_policies": {
                             [this.app.uuid]: {}
                         }


### PR DESCRIPTION
Fixes #95 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
Run full automated test suite and manually verify that policy table previews display correctly in the UI, as well as in policy table POST requests.

### Summary
Introduces short App IDs (truncated versions of full App IDs) to support legacy head units incapable of handling IDs longer than 10 characters. Default behavior is to use these short App IDs rather than full App IDs. New `full_app_id_supported` attribute inside of the `module_config` property of a policy table indicates whether to interpret and respond using short or full App IDs.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* Policy tables are now built with short App IDs by default. Full App IDs can still be requested via the `full_app_id_supported` boolean parameter inside of `module_config` during a policy table update POST request.

##### Bug Fixes
* See enhancements.