### PR TITLE
Hotfix/functional group pt structure

### DIFF
--- a/app/v1/groups/sql.js
+++ b/app/v1/groups/sql.js
@@ -67,7 +67,7 @@ function getFuncGroupStatus (isProduction, hideDeleted = false) {
     const funcGroupsGroup = sql.select('max(id) AS id', 'property_name')
         .from('view_function_group_info')
         .groupBy('property_name');
-        
+
     let funcGroupsStaging = sql.select('view_function_group_info.*')
         .from('(' + funcGroupsGroup + ') vfgi')
         .innerJoin('view_function_group_info', {
@@ -104,6 +104,19 @@ function getFuncGroupStatus (isProduction, hideDeleted = false) {
 
 function getFuncGroupHmiLevelsStatus (isProduction, hideDeleted = false) {
     return sql.select('function_group_id', 'permission_name', 'hmi_level')
+        .select(
+            '(' + sql.select('COUNT(pr.parent_permission_name)')
+                .from('permission_relations pr')
+                .join('permissions p', {
+                    'p.name': 'pr.parent_permission_name'
+                })
+                .where({
+                    'pr.parent_permission_name': sql('function_group_hmi_levels.permission_name'),
+                    'p.type': 'PARAMETER'
+                })
+                .toString()
+            + ') AS possible_parameter_count'
+        )
         .from('(' + getFuncGroupStatus(isProduction, hideDeleted) + ') fgi')
         .innerJoin('function_group_hmi_levels', {
             'fgi.id': 'function_group_hmi_levels.function_group_id'

--- a/app/v1/groups/sql.js
+++ b/app/v1/groups/sql.js
@@ -108,7 +108,7 @@ function getFuncGroupHmiLevelsStatus (isProduction, hideDeleted = false) {
             '(' + sql.select('COUNT(pr.parent_permission_name)')
                 .from('permission_relations pr')
                 .join('permissions p', {
-                    'p.name': 'pr.parent_permission_name'
+                    'p.name': 'pr.child_permission_name'
                 })
                 .where({
                     'pr.parent_permission_name': sql('function_group_hmi_levels.permission_name'),

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -189,7 +189,8 @@ function transformFunctionalGroups (isProduction, info, next) {
                 if (hmiLevels.length > 0) {
                     data.hmi_levels = hmiLevels;
                 }
-                if (parameters.length > 0) {
+                //if (parameters.length > 0) {
+                if (data.possible_parameter_count > 0) {
                     //sort the parameters array
                     data.parameters = parameters.sort();
                 }

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -146,6 +146,7 @@ function transformFunctionalGroups (isProduction, info, next) {
                 groupedData[funcId].rpcs[hmiLevel.permission_name] = {};
                 groupedData[funcId].rpcs[hmiLevel.permission_name].hmi_levels = {};
                 groupedData[funcId].rpcs[hmiLevel.permission_name].parameters = {};
+                groupedData[funcId].rpcs[hmiLevel.permission_name].possible_parameter_count = parseInt(hmiLevel.possible_parameter_count) || 0;
             }
             groupedData[funcId].rpcs[hmiLevel.permission_name].hmi_levels[hmiLevel.hmi_level] = true;
             next();
@@ -189,11 +190,12 @@ function transformFunctionalGroups (isProduction, info, next) {
                 if (hmiLevels.length > 0) {
                     data.hmi_levels = hmiLevels;
                 }
-                //if (parameters.length > 0) {
+
                 if (data.possible_parameter_count > 0) {
                     //sort the parameters array
                     data.parameters = parameters.sort();
                 }
+                delete data.possible_parameter_count;
             }
             callback();
         }, next);

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -241,7 +241,9 @@ function constructAppPolicy (appObj, useLongUuids = false, res, next) {
         priority: "NONE",
         default_hmi: appObj.default_hmi_level.split("_")[1], //trim the HMI_ prefix
         groups: funcGroupNames,
-        moduleType: moduleNames
+        moduleType: moduleNames,
+        RequestType: [],
+        RequestSubType: []
     };
     next(null, appPolicyObj);
 }
@@ -284,7 +286,9 @@ function aggregateResults (res, next) {
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": defaultFuncGroups
+        "groups": defaultFuncGroups,
+        "RequestType": [],
+        "RequestSubType": []
     };
     //DataConsent-2 functional group removed
     appPolicy.device = {
@@ -292,7 +296,9 @@ function aggregateResults (res, next) {
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": deviceFuncGroups
+        "groups": deviceFuncGroups,
+        "RequestType": [],
+        "RequestSubType": []
     };
     //BaseBeforeDataConsent functional group removed
     appPolicy.pre_DataConsent = {
@@ -300,7 +306,9 @@ function aggregateResults (res, next) {
         "steal_focus": false,
         "priority": "NONE",
         "default_hmi": "NONE",
-        "groups": preDataConsentFuncGroups
+        "groups": preDataConsentFuncGroups,
+        "RequestType": [],
+        "RequestSubType": []
     };
     next(null, appPolicy);
 }


### PR DESCRIPTION
Fixes #104 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
RPCs in functional groups with no parameters (when parameters are available) will now return an empty `parameters` array. Additionally, `RequestType` and `RequestSubType` were added as empty arrays to all `app_policies` at the direction of the SDL Core team.