### PR TITLE
Feature/auto approve all apps

### DIFF
--- a/app/v1/about/controller.js
+++ b/app/v1/about/controller.js
@@ -23,6 +23,7 @@ exports.getInfo = function (req, res, next) {
 		"ssl_port": config.policyServerPortSSL,
 		"cache_module": config.cacheModule,
 		"auth_type": config.authType,
+		"auto_approve_all_apps": config.autoApproveAllApps,
 		"base_url": protocol + config.policyServerHost + concatPort
 	};
 

--- a/app/v1/applications/helper.js
+++ b/app/v1/applications/helper.js
@@ -173,7 +173,7 @@ function autoApprovalModifier (appObj, next) {
 
 // Auto deny new application versions of an app that is blacklisted
 function autoBlacklistModifier (appObj, next) {
-	db.sqlCommand(sql.getBlacklistedApps(appObj.uuid, true), function (err, res) {
+	db.sqlCommand(sql.getBlacklistedAppFullUuids(appObj.uuid), function (err, res) {
 		if (res.length > 0) {
 			appObj.approval_status = 'LIMITED';
 		}

--- a/app/v1/applications/helper.js
+++ b/app/v1/applications/helper.js
@@ -7,6 +7,7 @@ const flow = app.locals.flow;
 const flame = app.locals.flame;
 const log = app.locals.log;
 const db = app.locals.db;
+const config = app.locals.config;
 
 //validation functions
 
@@ -151,6 +152,15 @@ function filterApps (includeApprovalStatus, appObjs, next) {
 
 //auto changes any app's approval status to ACCEPTED if a record was found for that app's uuid in the auto approval table
 function autoApprovalModifier (appObj, next) {
+
+	// check if auto-approve *all apps* is enabled
+	if(config.autoApproveAllApps){
+		appObj.approval_status = 'ACCEPTED';
+		next(null, appObj);
+		return;
+	}
+
+	// check if auto-approve this specific app is enabled
     db.sqlCommand(sql.checkAutoApproval(appObj.uuid), function (err, res) {
         //if res is not an empty array, then a record was found in the app_auto_approval table
         //change the status of this appObj to ACCEPTED

--- a/app/v1/applications/sql.js
+++ b/app/v1/applications/sql.js
@@ -411,6 +411,16 @@ function getBlacklistedApps (uuids, useLongUuids = false) {
     return query.toString();
 }
 
+function getBlacklistedAppFullUuids (uuids) {
+    var query = sql.select('app_blacklist.app_uuid')
+        .from('app_blacklist')
+        .where(
+            sql.in('app_blacklist.app_uuid', uuids)
+        );
+
+    return query.toString();
+}
+
 module.exports = {
     changeAppApprovalStatus: changeAppApprovalStatus,
     deleteAutoApproval: deleteAutoApproval,
@@ -456,5 +466,6 @@ module.exports = {
     insertAppAutoApproval: insertAppAutoApproval,
     insertAppBlacklist: insertAppBlacklist,
     deleteAppBlacklist: deleteAppBlacklist,
-    getBlacklistedApps: getBlacklistedApps
+    getBlacklistedApps: getBlacklistedApps,
+    getBlacklistedAppFullUuids: getBlacklistedAppFullUuids
 }

--- a/documentation/guides/docs/Getting Started/Installation/index.md
+++ b/documentation/guides/docs/Getting Started/Installation/index.md
@@ -26,32 +26,33 @@ Once you set up a database (locally or remotely) you'll need to supply the Polic
 
 Here are the environment variables that will most likely be used:
 
-* `POLICY_SERVER_HOST`: The hostname or public IP address which the server runs on.
-* `POLICY_SERVER_PORT`: The port which the server runs on. It is optional and the default is 3000.
-* `POLICY_SERVER_PORT_SSL`: The port which the server should listen for SSL connections on (typically 443). It is optional and the default is `null` (do not listen for SSL connections).
-* `SSL_CERTIFICATE_FILENAME`: The filename of the SSL certificate located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
-* `SSL_PRIVATE_KEY_FILENAME`: The filename of the SSL certificate's private key located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
-* `SHAID_PUBLIC_KEY`: A public key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
-* `SHAID_SECRET_KEY`: A secret key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
-* `DB_USER`: The name of the user to allow the server to access the database
-* `DB_DATABASE`: The name of the database where polciy and app data is stored
-* `DB_PASSWORD`: The password used to log into the database
-* `DB_HOST`: The host name or IP address of the database
-* `DB_PORT`: The port number of the database
-* `STAGING_PG_USER` **DEPRECATED**: The name of the user to allow the server access the database (staging mode)
-* `STAGING_PG_DATABASE` **DEPRECATED**: The name of the database where policy and app data is stored (staging mode)
-* `STAGING_PG_PASSWORD` **DEPRECATED**: The password used to log into the database (staging mode)
-* `STAGING_PG_HOST` **DEPRECATED**: The host name or IP address of the database (staging mode)
-* `STAGING_PG_PORT` **DEPRECATED**: The port number of the database (staging mode)
-* `PRODUCTION_PG_USER` **DEPRECATED**: The name of the user to allow the server access the database (production mode)
-* `PRODUCTION_PG_DATABASE` **DEPRECATED**: The name of the database where policy and app data is stored (production mode)
-* `PRODUCTION_PG_PASSWORD` **DEPRECATED**: The password used to log into the database (production mode)
-* `PRODUCTION_PG_HOST` **DEPRECATED**: The host name or IP address of the database (production mode)
-* `PRODUCTION_PG_PORT` **DEPRECATED**: The port number of the database (production mode)
-* `CACHE_MODULE`: The name of the caching module to use. Currently supports null (no caching, default) or "redis".
-* `CACHE_HOST`: The host name or IP address of the cache
-* `CACHE_PORT`: The port number of the cache
-* `CACHE_PASSWORD`: The password used to log into the cache
+* `POLICY_SERVER_HOST`: String. The hostname or public IP address which the server runs on.
+* `POLICY_SERVER_PORT`: Integer. The port which the server runs on. It is optional and the default is 3000.
+* `POLICY_SERVER_PORT_SSL`: Integer. The port which the server should listen for SSL connections on (typically 443). It is optional and the default is `null` (do not listen for SSL connections).
+* `SSL_CERTIFICATE_FILENAME`: String. The filename of the SSL certificate located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
+* `SSL_PRIVATE_KEY_FILENAME`: String. The filename of the SSL certificate's private key located in `./customizable/ssl`. Required if a value is set for `POLICY_SERVER_PORT_SSL`.
+* `SHAID_PUBLIC_KEY`: String. A public key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
+* `SHAID_SECRET_KEY`: String. A secret key given to you through the [developer portal](https://smartdevicelink.com/) that allows access to SHAID endpoints.
+* `DB_USER`: String. The name of the user to allow the server to access the database
+* `DB_DATABASE`: String. The name of the database where policy and app data is stored
+* `DB_PASSWORD`: String. The password used to log into the database
+* `DB_HOST`: String. The host name or IP address of the database
+* `DB_PORT`: Integer. The port number of the database
+* `STAGING_PG_USER` **DEPRECATED**: String. The name of the user to allow the server access the database (staging mode)
+* `STAGING_PG_DATABASE` **DEPRECATED**: String. The name of the database where policy and app data is stored (staging mode)
+* `STAGING_PG_PASSWORD` **DEPRECATED**: String. The password used to log into the database (staging mode)
+* `STAGING_PG_HOST` **DEPRECATED**: String. The host name or IP address of the database (staging mode)
+* `STAGING_PG_PORT` **DEPRECATED**: Integer. The port number of the database (staging mode)
+* `PRODUCTION_PG_USER` **DEPRECATED**: String. The name of the user to allow the server access the database (production mode)
+* `PRODUCTION_PG_DATABASE` **DEPRECATED**: String. The name of the database where policy and app data is stored (production mode)
+* `PRODUCTION_PG_PASSWORD` **DEPRECATED**: String. The password used to log into the database (production mode)
+* `PRODUCTION_PG_HOST` **DEPRECATED**: String. The host name or IP address of the database (production mode)
+* `PRODUCTION_PG_PORT` **DEPRECATED**: Integer. The port number of the database (production mode)
+* `CACHE_MODULE`: String. The name of the caching module to use. Currently supports null (no caching, default) or "redis".
+* `CACHE_HOST`: String. The host name or IP address of the cache. Default null.
+* `CACHE_PORT`: Integer. The port number of the cache. Default null.
+* `CACHE_PASSWORD`: String. The password used to log into the cache. Default null.
+* `AUTO_APPROVE_ALL_APPS`: String boolean ("true" or "false"). Whether or not to auto-approve all app versions received by SHAID (except for blacklisted apps). Default "false".
 
 Production/Staging environment variables for the database are now deprecated. Please use the corresponding `DB_` values in place of them (ex. `DB_USER` instead of `PRODUCTION_PG_USER` or `STAGING_PG_USER`).
 

--- a/settings.js
+++ b/settings.js
@@ -31,6 +31,8 @@ module.exports = {
     authType: process.env.AUTH_TYPE || null,
     //an optional password users must enter to access the Policy Server interface when paired with "basic" authType
     basicAuthPassword: process.env.BASIC_AUTH_PASSWORD || null,
+    //whether or not to auto-approve all app versions received by SHAID (unless specifically blacklisted)
+    autoApproveAllApps: process.env.AUTO_APPROVE_ALL_APPS == "true" ? true : false,
     //credentials for using the SHAID API
     shaidPublicKey: process.env.SHAID_PUBLIC_KEY,
     shaidSecretKey: process.env.SHAID_SECRET_KEY,

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -60,7 +60,7 @@
                                     style=""
                                     aria-hidden="true">
                                 </i>
-                                <label class="col-form-label color-primary mt-0 ml-1" style="text-transform:none">SSL {{ about.ssl_port ? `enabled on port ${about.ssl_port}` : `disabled` }}</label>
+                                <label class="col-form-label color-primary mt-0 ml-1" style="text-transform:none">SSL: {{ about.ssl_port ? `enabled (port ${about.ssl_port})` : `disabled` }}</label>
                             </div>
                         </div>
                     </div>
@@ -80,7 +80,7 @@
                                     style=""
                                     aria-hidden="true">
                                 </i>
-                                <label class="col-form-label color-primary ml-1" style="text-transform:none">Caching {{ about.cache_module ? `enabled: ${about.cache_module}` : `disabled` }}</label>
+                                <label class="col-form-label color-primary ml-1" style="text-transform:none">Caching: {{ about.cache_module ? `enabled (${about.cache_module})` : `disabled` }}</label>
                             </div>
                         </div>
                     </div>
@@ -100,7 +100,27 @@
                                     style=""
                                     aria-hidden="true">
                                 </i>
-                                <label class="col-form-label color-primary ml-1" style="text-transform:none">Authentication {{ about.auth_type ? `enabled: ${about.auth_type}` : `disabled` }}</label>
+                                <label class="col-form-label color-primary ml-1" style="text-transform:none">Authentication: {{ about.auth_type ? `enabled (${about.auth_type})` : `disabled` }}</label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-row m-0">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <i
+                                    v-if="about.auto_approve_all_apps"
+                                    class="fa fa-check-circle color-green"
+                                    style=""
+                                    aria-hidden="true">
+                                </i>
+                                <i
+                                    v-else
+                                    class="fa fa-times-circle color-red"
+                                    style=""
+                                    aria-hidden="true">
+                                </i>
+                                <label class="col-form-label color-primary ml-1" style="text-transform:none">Auto-approve incoming apps: {{ about.auto_approve_all_apps ? `enabled` : `disabled` }}</label>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #106 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Ensure new app versions are "PENDING" when the new configuration toggle is disabled. 
- Ensure new app versions are set to "ACCEPTED" when the new configuration toggle is enabled and the processed app is *not* blacklisted on the Policy Server. 
- Ensure new app versions are set to "LIMITED" when the new configuration toggle is enabled but the app is blacklisted on the Policy Server.

### Summary
Added an environment variable configuration option to auto-approve new app versions retrieved by SHAID, as long as the app hasn't been blacklisted by the OEM.