### PR TITLE
Semantic version update checking

### DIFF
--- a/app/v1/about/controller.js
+++ b/app/v1/about/controller.js
@@ -3,11 +3,13 @@ const async = require('async');
 const config = require('../../../settings.js');
 const packageJson = require('../../../package.json'); //configuration module
 const requestjs = require('request');
+const semver = require('semver');
 
 exports.getInfo = function (req, res, next) {
 	var data = {
 		"current_version": packageJson.version,
 		"latest_version": packageJson.version,
+		"is_update_available": false,
 		"ssl_port": config.policyServerPortSSL,
 		"cache_module": config.cacheModule,
 		"auth_type": config.authType,
@@ -38,6 +40,8 @@ exports.getInfo = function (req, res, next) {
 		if(!err && response.statusCode >= 200 && response.statusCode < 300){
 			// success!
 			data.latest_version = body.version;
+			data.is_update_available = semver.lt(data.current_version, data.latest_version);
+			data.update_type = semver.diff(data.current_version, data.latest_version);
 		}
 
 		res.parcel.setStatus(200)

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "optimize-css-assets-webpack-plugin": "2.0.0",
     "ora": "1.2.0",
     "rimraf": "2.6.0",
-    "semver": "5.3.0",
+    "semver": "^5.3.0",
     "shelljs": "0.7.6",
     "url-loader": "0.5.8",
     "vue-loader": "13.0.4",

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -15,7 +15,7 @@
                         <h4 for="name">Version {{ about.current_version }}</h4>
                         <div class="row">
                             <div class="col-sm-12">
-                                <template v-if="!updateAvailable">
+                                <template v-if="!isUpdateAvailable">
                                     <i
                                         class="fa fa-check-circle color-green"
                                         style=""
@@ -158,15 +158,15 @@
     export default {
         data () {
             return {
-                "about": null
+                "about": {}
             }
         },
         computed: {
             fieldsDisabled: function () {
                 return true;
             },
-            updateAvailable: function () {
-                return (this.about && this.about.current_version != this.about.latest_version);
+            isUpdateAvailable: function(){
+                return this.about.is_update_available;
             }
         },
         methods: {

--- a/src/components/common/Footer.vue
+++ b/src/components/common/Footer.vue
@@ -1,7 +1,7 @@
 <template>
-    <nav v-if="isDifferentVersion()" class="navbar fixed-bottom upgrade-alert">
+    <nav v-if="isUpdateAvailable()" class="navbar fixed-bottom upgrade-alert">
         <div class="mx-auto h-100">
-            <span class="align-middle text-center">** Notice: A new version of the SDL Policy Server (v{{latest_version}}) is available.</span>
+            <span class="align-middle text-center">{{ (about.update_type ? "A " + about.update_type + " " : "An") }} update (v{{about.latest_version}}) is available for your SDL Server.</span>
             <a href="https://github.com/smartdevicelink/sdl_server" target="_blank">
                 <button type="button" class="btn btn-update btn-sm h-100">Update Now</button>
             </a>
@@ -13,36 +13,26 @@
 export default {
     data: function(){
         return {
-            "latest_version": null,
-            "current_version": "1.0.0"
+            "about": {}
         };
     },
     methods: {
-        isDifferentVersion: function(){
-            return (this.latest_version != null && this.latest_version !== this.current_version);
+        isUpdateAvailable: function(){
+            return this.about.is_update_available;
         }
     },
-    created: function(){
-        //get current version
-        this.httpRequest("get", "/version", {}, (err, response) => {
+    created (){
+        this.httpRequest("get", "about", {}, (err, response) => {
             if(err){
                 // error
-                console.log("Error checking local Policy Server version.");
-                console.log(err);
+                console.log("Error receiving about info.");
+                console.log(response);
             }else{
                 // success
-                this.current_version = response.body;
+                response.json().then(parsed => {
+                    this.about = parsed.data;
+                });
             }
-        });
-
-        this.$http.get("https://raw.githubusercontent.com/smartdevicelink/sdl_server/master/package.json").then(response => {
-            // success
-            response.json().then(parsed => {
-                this.latest_version = parsed.version;
-            });
-        }, response => {
-            // error
-            console.log("Error checking remote Policy Server version. Status code: " + response.status);
         });
     }
 }


### PR DESCRIPTION
Fixes #130 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Ensure the update footer bar does not appear on prerelease versions (any version ahead of the master branch). Temporarily modify local `package.json` to test notifications for patch, minor, and major version updates.

### Summary
Compares semantic version strings of the local SDL Server `package.json` file and the version in the `master` branch of this repository. Now displays what type of update is available in the footer notification, if any.