### PR TITLE
added multiple module related rpcs

### DIFF
--- a/migrations/20190829193834-multiple-modules-0221.js
+++ b/migrations/20190829193834-multiple-modules-0221.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190829193834-multiple-modules-0221-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190829193834-multiple-modules-0221-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190829193834-multiple-modules-0221-down.sql
+++ b/migrations/sqls/20190829193834-multiple-modules-0221-down.sql
@@ -1,0 +1,1 @@
+/** Intentionally left blank. If an OEM runs a down migration, we do not want to delete functional groups that may have been updated. **/

--- a/migrations/sqls/20190829193834-multiple-modules-0221-up.sql
+++ b/migrations/sqls/20190829193834-multiple-modules-0221-up.sql
@@ -1,0 +1,29 @@
+/* db-migrate create show-app-menu-0116 -e pg-staging */
+
+INSERT INTO function_group_hmi_levels(function_group_id, permission_name, hmi_level)
+SELECT id AS function_group_id, 'ReleaseInteriorVehicleDataModule' AS permission_name, v.hmi_level::hmi_level AS hmi_level
+FROM function_group_info
+CROSS JOIN (
+    VALUES ('FULL'), ('LIMITED'), ('BACKGROUND'), ('NONE')
+) AS v(hmi_level)
+WHERE property_name = 'RemoteControl'
+    AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_hmi_levels
+        WHERE property_name = 'RemoteControl'
+            AND permission_name = 'ReleaseInteriorVehicleDataModule'
+    );
+
+INSERT INTO function_group_hmi_levels(function_group_id, permission_name, hmi_level)
+SELECT id AS function_group_id, 'GetInteriorVehicleDataConsent' AS permission_name, v.hmi_level::hmi_level AS hmi_level
+FROM function_group_info
+CROSS JOIN (
+    VALUES ('FULL'), ('LIMITED'), ('BACKGROUND'), ('NONE')
+) AS v(hmi_level)
+WHERE property_name = 'RemoteControl'
+    AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_hmi_levels
+        WHERE property_name = 'RemoteControl'
+            AND permission_name = 'GetInteriorVehicleDataConsent'
+    );


### PR DESCRIPTION
Fixes # 137

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Confirm RPCs ReleaseInterior and GetInteriorVehicleDataConsent are under the RemoteControl functional group. 

### Summary
Created new RPCs ReleaseInteriorVehicleDataModule and GetInteriorVehicleDataConsent and added these to the existing functional group ReleaseInteriorVehicleDataModule with default level NONE.

### Changelog
##### Breaking Changes
None

##### Enhancements
Added the support for new RPCs ReleaseInterior and GetInteriorVehicleDataConsent.

##### Bug Fixes
None

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)