### PR TITLE
Limit retry second count array to max of 5 entries

### DIFF
--- a/app/v1/module-config/helper.js
+++ b/app/v1/module-config/helper.js
@@ -36,9 +36,6 @@ function validatePost (req, res) {
             return setError(req.body.seconds_between_retries[i] + " is not a number");
         }
     }
-    if (req.body.seconds_between_retries.length > 5) {
-        return setError("Array length of seconds_between_retries is greater than 5");
-    }
     if (!req.body.endpoints) {
         return setError("endpoints object required");
     }

--- a/app/v1/module-config/helper.js
+++ b/app/v1/module-config/helper.js
@@ -36,6 +36,9 @@ function validatePost (req, res) {
             return setError(req.body.seconds_between_retries[i] + " is not a number");
         }
     }
+    if (req.body.seconds_between_retries.length > 5) {
+        return setError("Array length of seconds_between_retries is greater than 5");
+    }
     if (!req.body.endpoints) {
         return setError("endpoints object required");
     }

--- a/src/components/ModuleConfig.vue
+++ b/src/components/ModuleConfig.vue
@@ -109,7 +109,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div v-if="!fieldsDisabled" v-on:click="addRetryUpdateElement()" id="add" class="another-rpc pointer">
+                            <div v-if="!fieldsDisabled && module_config.seconds_between_retries.length < 5" v-on:click="addRetryUpdateElement()" id="add" class="another-rpc pointer">
                                 <i class="fa fa-plus middle-middle"></i>
                             </div>
                     </div>


### PR DESCRIPTION
Fixes #210 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Adds just a front-end check to make sure that the retry seconds array count doesn't exceed 5 entries.