### PR TITLE
Remove the delete button for en-us consumer message fields

### DIFF
--- a/src/components/common/MessageItem.vue
+++ b/src/components/common/MessageItem.vue
@@ -4,7 +4,7 @@
         <h5>{{ item.language_id }}
             <i
                 v-on:click="removeLanguage()"
-                v-if="!fieldsDisabled"
+                v-if="!fieldsDisabled && item.language_id !== 'en-us'"
                 class="pointer pull-right fa fa-times hover-color-red"
                 aria-hidden="true">
             </i>


### PR DESCRIPTION
Fixes #212 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Removes the delete button for the consumer message en-us boxes to keep policy tables valid.