### PR TITLE
Pass in serialNumber to cert generation from app details page

### DIFF
--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -564,6 +564,7 @@ export default {
                 "emailAddress": "",
                 "days": "",
                 "private_key": null,
+                "serialNumber": ""
             },
             "private_key": null,
             "certificate": null,
@@ -828,6 +829,8 @@ export default {
                     response.json().then(parsed => {
                         if(parsed.data.applications.length){
                             this.app = parsed.data.applications[0];
+                            // ensure the serial number is auto-included in cert generation!
+                            this.certificate_options.serialNumber = this.app.uuid; 
                             this.private_key = this.app.private_key;
                             this.certificate = this.app.certificate;
                             this.selected_hybrid_app_preference = this.hybrid_dropdown_options[this.app.hybrid_app_preference || "BOTH"];


### PR DESCRIPTION
Fixes #214 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
After generating a certificate manually through the button in the app details, copy the certificate value and run it through openssl to read if it contains the serialNumber still: `openssl x509 -in certificate.pem -text -noout`

### Summary
Fixes the issue with serialNumber not being passed in newly created certificates for a specific app