### PR TITLE
Remove filtering to avoid indexing issues with inner elements

### DIFF
--- a/src/components/ConsumerMessageDetails.vue
+++ b/src/components/ConsumerMessageDetails.vue
@@ -28,7 +28,7 @@
                     <div class="form-row">
                         <h4>Languages</h4>
                         <message-item
-                            v-for="(value, key) in message.languages.filter(value => value.selected)"
+                            v-for="(value, key) in message.languages"
                             v-bind:item="value"
                             v-bind:fieldsDisabled="fieldsDisabled"
                             v-bind:environment="environment"
@@ -62,14 +62,16 @@
             <b-modal ref="addLanguageModal" title="Select Language" hide-footer id="addLanguageModal" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
                 <input v-model="lang_search" placeholder="Search for a language" class="form-control" id="lang-search">
                 <ul class="list-group rpc-list">
-                    <li
-                        class="list-group-item rpc-list-item pointer"
-                        v-for="(value, key) in message.languages.filter(value => isLangAvailable(value))"
+                    <div
+                        v-for="(value, key) in message.languages"
                         v-on:click="addLanguage(value)"
-                        v-bind:key="key"
-                    >
-                    {{ value.language_id }}
-                    </li>
+                        v-bind:key="key">
+                        <li
+                            class="list-group-item rpc-list-item pointer"
+                            v-if="isLangAvailable(value)">
+                            {{ value.language_id }}
+                        </li>
+                    </div>
                 </ul>
             </b-modal>
 

--- a/src/components/FunctionalGroupDetails.vue
+++ b/src/components/FunctionalGroupDetails.vue
@@ -112,7 +112,7 @@
                         <h4 for="rpcs">RPCs</h4>
                         <div class="rpcs">
                             <rpc-item
-                                v-for="(item, index) in fg.rpcs.filter(rpc => rpc.selected)"
+                                v-for="(item, index) in fg.rpcs"
                                 v-bind:status="fg.status"
                                 v-bind:environment="environment"
                                 v-bind:fieldsDisabled="fieldsDisabled"
@@ -146,14 +146,16 @@
                     <input v-model="rpc_search" placeholder="Search for an RPC" class="form-control" id="rpc-search">
 
                     <ul class="list-group rpc-list">
-                        <li
-                            class="list-group-item rpc-list-item pointer"
-                            v-for="(item, index) in fg.rpcs.filter(item => isRpcAvailable(item))"
+                        <div 
+                            v-for="(item, index) in fg.rpcs"
                             v-on:click="addRpc(item)"
-                            v-bind:key="index"
-                        >
-                        {{ item.name }}
-                        </li>
+                            v-bind:key="index">
+                            <li 
+                                class="list-group-item rpc-list-item pointer"
+                                v-if="isRpcAvailable(item)">
+                                {{ item.name }}
+                            </li>
+                        </div>
                     </ul>
                 </b-modal>
 

--- a/src/components/common/MessageItem.vue
+++ b/src/components/common/MessageItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="white-box rpc-container">
+    <div v-if="item.selected" class="white-box rpc-container">
         <h5></h5>
         <h5>{{ item.language_id }}
             <i

--- a/src/components/common/RpcItem.vue
+++ b/src/components/common/RpcItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="white-box rpc-container">
+    <div v-if="item.selected" class="white-box rpc-container">
         <h5>{{ item.name }}
             <i
                 v-on:click="removeRpc()"


### PR DESCRIPTION
Fixes #216 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Removes the filtering in the consumer messages and functional group components to avoid indexing issues with the list elements. Also moves the conditional inside the element with the v-for to avoid placing v-if on the same element, per Vue's style guide.