### PR TITLE
Fix build process hanging

### DIFF
--- a/custom/cache/redis/index.js
+++ b/custom/cache/redis/index.js
@@ -2,14 +2,17 @@ const config = require('../../../settings.js');
 const log = require('../../loggers/winston');
 const Redis = require('redis');
 var redis;
-try {
-    redis = Redis.createClient({
-        port: config.cacheModulePort,
-        host: config.cacheModuleHost,
-        password: config.cacheModulePassword
-    });
-} catch (e) {
-    log.error('Cannot connect to Redis. Please check that your configuration is correct.');
+// Don't create the redis client when running the build process
+if (process.env.NODE_ENV !== "build") {
+    try {
+        redis = Redis.createClient({
+            port: config.cacheModulePort,
+            host: config.cacheModuleHost,
+            password: config.cacheModulePassword
+        });
+    } catch (e) {
+        log.error('Cannot connect to Redis. Please check that your configuration is correct.');
+    }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "npm run-script db-migrate-up && NODE_ENV=staging vue-cli-service serve",
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "NODE_ENV=build vue-cli-service build",
     "lint": "vue-cli-service lint",
     "start": "npm run dev",
     "test": "npm run db-migrate-reset-pg-test > /dev/null 2>&1 && npm run db-migrate-up-pg-test > /dev/null 2>&1 && NODE_ENV=test mocha",


### PR DESCRIPTION
Fixes #218 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run `npm run build` and `npm run start-server` to see the build processes complete.

### Summary
Sets the NODE_ENV environment variable to "build" when the build process is running. Adds a check for the build environment before starting the redis client.