### PR TITLE
Display endpoint path for webengine apps in details page

### DIFF
--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -94,7 +94,7 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
-                                    <th v-if="app.transport_type === 'webengine'">Entry Point Path</th>
+                                    <th v-if="app.transport_type === 'webengine'">Entrypoint Path</th>
                                     <th v-else>Endpoint</th>
                                     <th>Transport Type</th>
                                 </tr>

--- a/src/components/ApplicationDetails.vue
+++ b/src/components/ApplicationDetails.vue
@@ -94,13 +94,15 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
-                                    <th>Endpoint</th>
+                                    <th v-if="app.transport_type === 'webengine'">Entry Point Path</th>
+                                    <th v-else>Endpoint</th>
                                     <th>Transport Type</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>{{ app.cloud_endpoint }}</td>
+                                    <td v-if="app.transport_type === 'webengine'">{{ app.entrypoint_path }}</td>
+                                    <td v-else>{{ app.cloud_endpoint }}</td>
                                     <td>{{ app.cloud_transport_type }}</td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
In the app details page, webengine apps specifically will now show their entry point path instead of the websocket endpoint path for other embedded apps.