### PR TITLE
Feature/0269 climate data

### DIFF
--- a/migrations/20210120182618-seat-occupancy-0262.js
+++ b/migrations/20210120182618-seat-occupancy-0262.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210120182618-seat-occupancy-0262-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210120182618-seat-occupancy-0262-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20210129160807-climate-data-0269.js
+++ b/migrations/20210129160807-climate-data-0269.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210129160807-climate-data-0269-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210129160807-climate-data-0269-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20210120182618-seat-occupancy-0262-down.sql
+++ b/migrations/sqls/20210120182618-seat-occupancy-0262-down.sql
@@ -1,0 +1,1 @@
+/** Intentionally left blank. If an OEM runs a down migration, we do not want to delete functional groups that may have been updated. **/

--- a/migrations/sqls/20210120182618-seat-occupancy-0262-up.sql
+++ b/migrations/sqls/20210120182618-seat-occupancy-0262-up.sql
@@ -1,0 +1,92 @@
+-- DROP AFFECTED VIEWS --
+DROP VIEW IF EXISTS view_mapped_permissions_production;
+DROP VIEW IF EXISTS view_mapped_permissions_staging;
+DROP VIEW IF EXISTS view_mapped_permissions;
+DROP VIEW IF EXISTS view_function_group_info;
+-- END DROP OF VIEWS --
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'GetVehicleData' AS rpc_name, 'seatOccupancy' AS parameter
+FROM function_group_info
+WHERE property_name = 'DrivingCharacteristics-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'DrivingCharacteristics-3'
+            AND parameter = 'seatOccupancy'
+            AND rpc_name = 'GetVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'OnVehicleData' AS rpc_name, 'seatOccupancy' AS parameter
+FROM function_group_info
+WHERE property_name = 'DrivingCharacteristics-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'DrivingCharacteristics-3'
+            AND parameter = 'seatOccupancy'
+            AND rpc_name = 'OnVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'SubscribeVehicleData' AS rpc_name, 'seatOccupancy' AS parameter
+FROM function_group_info
+WHERE property_name = 'DrivingCharacteristics-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'DrivingCharacteristics-3'
+            AND parameter = 'seatOccupancy'
+            AND rpc_name = 'SubscribeVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'UnsubscribeVehicleData' AS rpc_name, 'seatOccupancy' AS parameter
+FROM function_group_info
+WHERE property_name = 'DrivingCharacteristics-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'DrivingCharacteristics-3'
+            AND parameter = 'seatOccupancy'
+            AND rpc_name = 'UnsubscribeVehicleData'
+    );
+
+-- RECREATE AFFECTED VIEWS --
+CREATE OR REPLACE VIEW view_function_group_info AS
+SELECT function_group_info.*
+FROM (
+SELECT property_name, status, max(id) AS id
+    FROM function_group_info
+    GROUP BY property_name, status
+) AS vfgi
+INNER JOIN function_group_info ON vfgi.id = function_group_info.id;
+
+CREATE OR REPLACE VIEW view_mapped_permissions AS
+SELECT function_group_id AS id, permission_name AS name, status, property_name, is_deleted
+FROM view_function_group_info
+INNER JOIN function_group_hmi_levels
+ON view_function_group_info.id = function_group_hmi_levels.function_group_id
+WHERE is_deleted=false
+UNION
+SELECT function_group_id AS id, parameter AS name, status, property_name, is_deleted
+FROM view_function_group_info
+INNER JOIN function_group_parameters
+ON view_function_group_info.id = function_group_parameters.function_group_id
+WHERE is_deleted=false;
+
+CREATE OR REPLACE VIEW view_mapped_permissions_staging AS
+SELECT view_mapped_permissions.*
+FROM view_mapped_permissions
+INNER JOIN (
+    SELECT max(id) AS id, property_name
+    FROM view_function_group_info
+    GROUP BY property_name
+) fgi
+ON view_mapped_permissions.id = fgi.id;
+
+CREATE OR REPLACE VIEW view_mapped_permissions_production AS
+SELECT view_mapped_permissions.* FROM view_mapped_permissions
+WHERE status = 'PRODUCTION';
+-- END VIEW RECREATION --

--- a/migrations/sqls/20210129160807-climate-data-0269-down.sql
+++ b/migrations/sqls/20210129160807-climate-data-0269-down.sql
@@ -1,0 +1,1 @@
+/** Intentionally left blank. If an OEM runs a down migration, we do not want to delete functional groups that may have been updated. **/

--- a/migrations/sqls/20210129160807-climate-data-0269-up.sql
+++ b/migrations/sqls/20210129160807-climate-data-0269-up.sql
@@ -1,0 +1,92 @@
+-- DROP AFFECTED VIEWS --
+DROP VIEW IF EXISTS view_mapped_permissions_production;
+DROP VIEW IF EXISTS view_mapped_permissions_staging;
+DROP VIEW IF EXISTS view_mapped_permissions;
+DROP VIEW IF EXISTS view_function_group_info;
+-- END DROP OF VIEWS --
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'GetVehicleData' AS rpc_name, 'climateData' AS parameter
+FROM function_group_info
+WHERE property_name = 'VehicleInfo-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'VehicleInfo-3'
+            AND parameter = 'climateData'
+            AND rpc_name = 'GetVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'OnVehicleData' AS rpc_name, 'climateData' AS parameter
+FROM function_group_info
+WHERE property_name = 'VehicleInfo-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'VehicleInfo-3'
+            AND parameter = 'climateData'
+            AND rpc_name = 'OnVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'SubscribeVehicleData' AS rpc_name, 'climateData' AS parameter
+FROM function_group_info
+WHERE property_name = 'VehicleInfo-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'VehicleInfo-3'
+            AND parameter = 'climateData'
+            AND rpc_name = 'SubscribeVehicleData'
+    );
+
+INSERT INTO function_group_parameters(function_group_id, rpc_name, parameter)
+SELECT id AS function_group_id, 'UnsubscribeVehicleData' AS rpc_name, 'climateData' AS parameter
+FROM function_group_info
+WHERE property_name = 'VehicleInfo-3'
+	AND NOT EXISTS(
+        SELECT 1
+        FROM function_group_parameters
+        WHERE property_name = 'VehicleInfo-3'
+            AND parameter = 'climateData'
+            AND rpc_name = 'UnsubscribeVehicleData'
+    );
+
+-- RECREATE AFFECTED VIEWS --
+CREATE OR REPLACE VIEW view_function_group_info AS
+SELECT function_group_info.*
+FROM (
+SELECT property_name, status, max(id) AS id
+    FROM function_group_info
+    GROUP BY property_name, status
+) AS vfgi
+INNER JOIN function_group_info ON vfgi.id = function_group_info.id;
+
+CREATE OR REPLACE VIEW view_mapped_permissions AS
+SELECT function_group_id AS id, permission_name AS name, status, property_name, is_deleted
+FROM view_function_group_info
+INNER JOIN function_group_hmi_levels
+ON view_function_group_info.id = function_group_hmi_levels.function_group_id
+WHERE is_deleted=false
+UNION
+SELECT function_group_id AS id, parameter AS name, status, property_name, is_deleted
+FROM view_function_group_info
+INNER JOIN function_group_parameters
+ON view_function_group_info.id = function_group_parameters.function_group_id
+WHERE is_deleted=false;
+
+CREATE OR REPLACE VIEW view_mapped_permissions_staging AS
+SELECT view_mapped_permissions.*
+FROM view_mapped_permissions
+INNER JOIN (
+    SELECT max(id) AS id, property_name
+    FROM view_function_group_info
+    GROUP BY property_name
+) fgi
+ON view_mapped_permissions.id = fgi.id;
+
+CREATE OR REPLACE VIEW view_mapped_permissions_production AS
+SELECT view_mapped_permissions.* FROM view_mapped_permissions
+WHERE status = 'PRODUCTION';
+-- END VIEW RECREATION --


### PR DESCRIPTION
Fixes #179 

This PR is ready for review. Note that this PR depends on the Seat Occupancy PR: https://github.com/smartdevicelink/sdl_server/pull/226

### Risk
This PR makes no API changes.

### Testing Plan
Change settings.js's rpcSpecXmlUrl property to https://raw.githubusercontent.com/LuxoftSDL/rpc_spec/feature/sdl_0269_new_vehicle_data_climateData/MOBILE_API.xml. Check that the new vehicle data is assigned to the functional group and that a newly approved app from SHAID requesting that permission is sent to the policy server and that the app will receive that functional group. 

### Summary
Adds the new vehicle data Climate Data to the VehicleInfo-3 functional group.