### PR TITLE
Do not return certificate info if feature is disabled

### DIFF
--- a/app/v1/module-config/controller.js
+++ b/app/v1/module-config/controller.js
@@ -31,6 +31,12 @@ function get(req, res, next) {
                 .setMessage('Internal server error')
                 .deliver();
         }
+        if (!certController.openSSLEnabled) { // cert gen not enabled
+            data.forEach(obj => {
+                delete obj.certificate;
+                delete obj.private_key
+            })
+        }
         return res.parcel
             .setStatus(200)
             .setData(

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -4,6 +4,7 @@ const settings = require('../../../settings.js');
 const sqlApp = require('../applications/sql.js');
 const _ = require('lodash');
 const vehicleDataHelper = require('../vehicle-data/helper.js');
+const certController = require('../certificates/controller');
 
 //module config
 
@@ -27,7 +28,7 @@ function transformModuleConfig (isProduction, useLongUuids = false, info, next) 
         concatPort = ":" + settings.policyServerPort;
     }
 
-    if(base.certificate && base.private_key){
+    if(certController.openSSLEnabled && base.certificate && base.private_key){
         base.certificate += '\n' + base.private_key;
     }
     else {


### PR DESCRIPTION
Fixes #240  

This PR is ready for review.

### Risk
This PR makes **minor** API changes.

### Summary
The certificate and private_key properties are no longer returned from GET module_config routes if certificate generation is disabled and certificates are already generated. Additionally, the certificate property will no longer appear in the module_config for any policy table requests under the same conditions. 