### PR TITLE
Staging endpoint for embedded app store

### DIFF
--- a/app/v1/app.js
+++ b/app/v1/app.js
@@ -82,6 +82,7 @@ function exposeRoutes () {
 	app.put('/applications/groups', auth.validateAuth, applications.putFunctionalGroup);
 	// webengine app store
 	app.get('/applications/store', cors(), applications.getAppStore);
+	app.get('/applications/staging/store', cors(), applications.getStagingAppStore);
 	app.post('/webhook', applications.webhook); //webhook route
 	//begin policy table routes
 	app.options('/staging/policy', cors())

--- a/app/v1/app.js
+++ b/app/v1/app.js
@@ -82,7 +82,7 @@ function exposeRoutes () {
 	app.put('/applications/groups', auth.validateAuth, applications.putFunctionalGroup);
 	// webengine app store
 	app.get('/applications/store', cors(), applications.getAppStore);
-	app.get('/applications/staging/store', cors(), applications.getStagingAppStore);
+	app.get('/applications/store/staging', cors(), applications.getStagingAppStore);
 	app.post('/webhook', applications.webhook); //webhook route
 	//begin policy table routes
 	app.options('/staging/policy', cors())


### PR DESCRIPTION
Fixes #251 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR adds a staging endpoint for the hmi to pull embedded app info from for its app store. This will allow a policy server maintainer to test these apps before moving them to production.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)