### PR TITLE
Add non-static consumer message versioning

### DIFF
--- a/app/v1/messages/sql.js
+++ b/app/v1/messages/sql.js
@@ -22,7 +22,8 @@ module.exports = {
         categoryByLanguage: getMessageCategoriesByLanguage,
         categoryByMaxId: getMessageCategoriesByMaxId,
         byIds: getMessagesByIdsStagingFilter,
-        groupsByIds: getMessageGroupsByIdsStagingFilter
+        groupsByIds: getMessageGroupsByIdsStagingFilter,
+        highestGroupId: getHighestMessageGroupId,
     },
     getMessageNamesStaging: getMessageNamesStaging,
     getLanguages: getLanguages,
@@ -42,6 +43,16 @@ function getMessagesStatus (isProduction) {
             .from('view_message_text_staging')
             .toString();
     }
+}
+
+//retrieve the highest id message group found
+function getHighestMessageGroupId (isProduction) {
+    let viewName = isProduction ? 'view_message_group_production' : 'view_message_group_staging';
+
+    let sqlString = sql.select('MAX(id) AS id')
+        .from(viewName);
+
+    return sqlString.toString();
 }
 
 //retrieve message group information such as categories

--- a/app/v1/policy/helper.js
+++ b/app/v1/policy/helper.js
@@ -119,7 +119,8 @@ function setupModuleConfig (isProduction, useLongUuids = false) {
 function setupConsumerFriendlyMessages (isProduction) {
     const getMessages = flame.flow({
         messageStatuses: setupSqlCommand.bind(null, messagesSql.getMessages.status(isProduction)),
-        messageGroups: setupSqlCommand.bind(null, messagesSql.getMessages.group(isProduction, false, true))
+        messageGroups: setupSqlCommand.bind(null, messagesSql.getMessages.group(isProduction, false, true)),
+        highestMessageGroupId: setupSqlCommand.bind(null, messagesSql.getMessages.highestGroupId(isProduction, false))
     }, {method: 'parallel'});
 
     const makeMessages = [

--- a/app/v1/policy/model.js
+++ b/app/v1/policy/model.js
@@ -107,6 +107,8 @@ function transformModuleConfig (isProduction, useLongUuids = false, info, next) 
 function transformMessages (info, cb) {
     const allMessages = info.messageStatuses;
     const groups = info.messageGroups;
+    const highestMessageGroupId = info.highestMessageGroupId[0] ? info.highestMessageGroupId[0].id : 0; // used to help generate a version number
+    const versionString = Number(highestMessageGroupId).toLocaleString().replace(/,/g,'.').padStart(11, "000."); // ###.###.### format up to the id of 999,999,999 
 
     const transformFlow = flame.flow([
         //hash the message groups by message_category
@@ -139,7 +141,7 @@ function transformMessages (info, cb) {
                 next();
             }, function () {
                 next(null, {
-                    "version": "000.000.001", //TODO: what to do with the versioning?
+                    "version": versionString,
                     "messages": messageObj
                 });
             });


### PR DESCRIPTION
Fixes #256 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
The policy server will now use the highest ID of the consumer message group to generate the version number, depending on the environment (STAGING or PRODUCTION), keeping the ###.###.### format up until an ID of a billion. This effectively ensures that the most recent changes to the messages will mean a new highest version.
