### PR TITLE
Fix to logging error in error branch

### DIFF
--- a/src/components/common/SideNav.vue
+++ b/src/components/common/SideNav.vue
@@ -67,7 +67,7 @@ export default {
                 if(err){
                     // error
                     console.log("Error fetching functional group data.");
-                    console.log(response);
+                    console.log(err);
                 }else{
                     // success
                     response.json().then(parsed => {


### PR DESCRIPTION
Fixes #263 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
The error branch in the SideNav httpRequest call now logs an error instead of the assumed successful response.