### PR TITLE
Bugfix/empty group message name fields

### DIFF
--- a/app/v1/messages/helper.js
+++ b/app/v1/messages/helper.js
@@ -20,6 +20,12 @@ function validatePromote (req, res) {
 
 function validatePost (req, res) {
     //base check
+    if (!check.string(req.body.name) || req.body.name === '') {
+        res.parcel
+            .setStatus(400)
+            .setMessage("Required field for consumer message: name");
+        return;
+    }
     if (!check.array(req.body.messages)) {
         res.parcel
             .setStatus(400)

--- a/src/components/ConsumerMessageDetails.vue
+++ b/src/components/ConsumerMessageDetails.vue
@@ -41,12 +41,19 @@
                         </div>
                     </div>
                     <!-- save button -->
+                    <div v-if="!isNameDefined()">
+                        <br>
+                        <p class="alert color-bg-red color-white d-table" role="alert">
+                            The name field must be defined.
+                        </p>
+                    </div>
+
                     <div>
                         <vue-ladda
                             type="submit"
                             class="btn btn-card"
                             data-style="zoom-in"
-                            v-if="!fieldsDisabled"
+                            v-if="!fieldsDisabled && isNameDefined()"
                             v-on:click="saveGroup()"
                             v-bind:loading="save_button_loading"
                             v-bind:class="{ 'btn-style-green': !message.is_deleted, 'btn-danger': message.is_deleted }">
@@ -217,7 +224,14 @@
                         });
                     }
                 });
-            }
+            },
+            "isNameDefined": function () {
+                if (!this.message.message_category) {
+                    return false; //no name defined
+                }
+
+                return true; //no issues
+            },
         },
         computed: {
             fieldsDisabled: function () {

--- a/src/components/FunctionalGroupDetails.vue
+++ b/src/components/FunctionalGroupDetails.vue
@@ -127,12 +127,20 @@
                         </div>
                     </div>
                     <!-- save button -->
+
+                    <div v-if="!isNameDefined()">
+                        <br>
+                        <p class="alert color-bg-red color-white d-table" role="alert">
+                            The name field must be defined.
+                        </p>
+                    </div>
+
                     <div>
                         <vue-ladda
                             type="submit"
                             class="btn btn-card"
                             data-style="zoom-in"
-                            v-if="!fieldsDisabled"
+                            v-if="!fieldsDisabled && isNameDefined()"
                             v-on:click="saveGroup()"
                             v-bind:loading="save_button_loading"
                             v-bind:class="{ 'btn-style-green': !fg.is_deleted, 'btn-danger': fg.is_deleted }">
@@ -375,7 +383,14 @@ import { eventBus } from '../main.js';
                         });
                     }
                 });
-            }
+            },
+            "isNameDefined": function () {
+                if (!this.fg.name) {
+                    return false; //no name defined
+                }
+
+                return true; //no issues
+            },
         },
         computed: {
             consentPromptOptions: function () {


### PR DESCRIPTION
Fixes #268 

Hold off on merging until #267 is merged.

This PR is not ready for review until #267 is merged.

### Risk
This PR makes no API changes.

### Summary
The save button on the consumer messages and functional group creation pages will be disabled until the user enters a name in the field. This avoids the issue of the server seeming like it saved the data but threw it out. The name field is also now part of the validation in the consumer message POST API. It was always required before, but the wrong result code was returned if no name field existed.
