### PR TITLE
Feature/docker environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright (c) 2022, Livio, Inc.
+FROM node:12
+
+ARG VERSION=master 
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssl \
+        curl \
+        git
+
+# Download SDL Core from github
+WORKDIR /usr
+
+RUN mkdir /usr/policy
+RUN git clone https://github.com/smartdevicelink/sdl_server.git /usr/policy -b $VERSION --depth=1
+
+WORKDIR /usr/policy
+
+RUN npm install
+RUN npm install aws-sdk node-stream-zip --save
+
+COPY .env .env
+COPY wait-for-it.sh wait-for-it.sh
+COPY keys customizable/ca
+COPY webengine-bundle.js customizable/webengine-bundle/index.js
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git
 
-# Download SDL Core from github
+# Download SDL Server from github
 WORKDIR /usr
 
 RUN mkdir /usr/policy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,11 +19,11 @@ WORKDIR /usr/policy
 RUN npm install
 RUN npm install aws-sdk node-stream-zip --save
 
-COPY .env .env
 COPY wait-for-it.sh wait-for-it.sh
 COPY keys customizable/ca
+COPY keys customizable/ssl
 COPY webengine-bundle.js customizable/webengine-bundle/index.js
 
-EXPOSE 3000
+EXPOSE 3000 443
 
 CMD ["npm", "start"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,27 +1,29 @@
 ### Docker Compose Installation
 
-[Docker Engine is required to be installed.](https://docs.docker.com/engine/install/) This folder contains all the files needed to set up the policy server through docker images. The `docker-compose.yml` file will spin up the server, the Postgres database, and the Redis database and automatically connect them all (if redis is enabled). The policy server is made available on `http://localhost:3000`.
+[Docker Engine is required to be installed.](https://docs.docker.com/engine/install/) This folder contains all the files needed to set up the policy server through docker images. The `docker-compose.yml` file will spin up the server, the Postgres database, and the Redis database and automatically connect them all. The policy server is made available on `http://localhost:3000`.
 
 ### Environment Variables
 An `.env` file is expected in this directory, and the Dockerfile will pull in all environment variables from that file, just like how the policy server uses the `.env` file in the root directory. The Dockerfile uses the remote sdl_server repository instead of the local installation. The branch can be changed by changing the `docker-compose.yml` file's arg VERSION value: its default is the master branch.
 
-The following are notable `.env` variables to the docker environment. They are not a comprehensive list. The usual variables such as `SHAID_PUBLIC_KEY` and `SHAID_SECRET_KEY` are still required for usage.
+The following are notable `.env` variables to the docker environment. They are not a comprehensive list. The usual variables such as `SHAID_PUBLIC_KEY` and `SHAID_SECRET_KEY` are still required for usage. Connection to postgres and redis is automatic and no further configuration is required for them, such as setting environment variables.
 
 | Name               | Type   | Usage          | Description                                                               |
 |--------------------|--------|------------------|---------------------------------------------------------------------------|
-| DB_PASSWORD | String | Postgres      | Required to use the Postgres database container |
-| DB_HOST | String | Postgres      | Please set this value to "postgres" in your `.env` file. Only "postgres" will allow the policy server to connect to Postgres.|
-| DB_USER | String | Postgres      | Required to use the Postgres database container |
-| DB_DATABASE | String | Postgres      | Required to use the Postgres database container |
-| CACHE_HOST | String | Redis      | Please set this value to "redis" in your `.env` file. Only "redis" will allow the policy server to connect to Redis.|
+| DB_HOST | String | Postgres      | Please do not use this value. It is predefined to work with Docker Compose|
+| DB_PASSWORD | String | Postgres      | Not required to be set. Defaults to "postgres" |
+| DB_USER | String | Postgres      | Not required to be set. Defaults to "postgres" |
+| DB_DATABASE | String | Postgres      | Not required to be set. Defaults to "postgres" |
+| CACHE_HOST | String | Redis      | Please do not set this value. It is predefined to work with Docker Compose|
 | BUCKET_NAME | String | WebEngine app support      | The name of the S3 bucket to store app bundles |
 | AWS_REGION | String | WebEngine app support      | The region of the S3 bucket |
 | AWS_ACCESS_KEY_ID | String | WebEngine app support      | [AWS credentials to allow S3 usage](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html). These are exclusive to the docker install of the policy server! |
 | AWS_SECRET_ACCESS_KEY | String | WebEngine app support      | [AWS credentials to allow S3 usage](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html). These are exclusive to the docker install of the policy server! |
 
-Note the nearly empty `keys` subfolder. Insert your own key and pem files meant for the certificate generation feature in there, and the contents will be copied into the docker container policy server's  `customizable/ca` folder. You will still need the necessary environment variables to activate certificate generation.
+Note the nearly empty `keys` subfolder. Insert your own key and pem files meant for the certificate generation feature and SSL connections in there, and the contents will be copied into the docker container policy server's `customizable/ca` folder and `customizable/ssl` folder. You will still need the necessary environment variables to activate certificate generation and SSL connections respectively.
 
 ### Commands
+You need to run the following commands in this directory (the docker directory of the project).
+
 To start a new or existing cluster, remembering to rebuild the policy server image in case of .env changes:
 `docker compose up --build`
 Use Ctrl+C once to stop all the docker containers. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+### Docker Compose Installation
+
+[Docker Engine is required to be installed.](https://docs.docker.com/engine/install/) This folder contains all the files needed to set up the policy server through docker images. The `docker-compose.yml` file will spin up the server, the Postgres database, and the Redis database and automatically connect them all (if redis is enabled). The policy server is made available on `http://localhost:3000`.
+
+### Environment Variables
+An `.env` file is expected in this directory, and the Dockerfile will pull in all environment variables from that file, just like how the policy server uses the `.env` file in the root directory. The Dockerfile uses the remote sdl_server repository instead of the local installation. The branch can be changed by changing the `docker-compose.yml` file's arg VERSION value: its default is the master branch.
+
+The following are notable `.env` variables to the docker environment. They are not a comprehensive list. The usual variables such as `SHAID_PUBLIC_KEY` and `SHAID_SECRET_KEY` are still required for usage.
+
+| Name               | Type   | Usage          | Description                                                               |
+|--------------------|--------|------------------|---------------------------------------------------------------------------|
+| DB_PASSWORD | String | Postgres      | Required to use the Postgres database container |
+| DB_HOST | String | Postgres      | Please set this value to "postgres" in your `.env` file. Only "postgres" will allow the policy server to connect to Postgres.|
+| DB_USER | String | Postgres      | Required to use the Postgres database container |
+| DB_DATABASE | String | Postgres      | Required to use the Postgres database container |
+| CACHE_HOST | String | Redis      | Please set this value to "redis" in your `.env` file. Only "redis" will allow the policy server to connect to Redis.|
+| BUCKET_NAME | String | WebEngine app support      | The name of the S3 bucket to store app bundles |
+| AWS_REGION | String | WebEngine app support      | The region of the S3 bucket |
+| AWS_ACCESS_KEY_ID | String | WebEngine app support      | [AWS credentials to allow S3 usage](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html). These are exclusive to the docker install of the policy server! |
+| AWS_SECRET_ACCESS_KEY | String | WebEngine app support      | [AWS credentials to allow S3 usage](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html). These are exclusive to the docker install of the policy server! |
+
+Note the nearly empty `keys` subfolder. Insert your own key and pem files meant for the certificate generation feature in there, and the contents will be copied into the docker container policy server's  `customizable/ca` folder. You will still need the necessary environment variables to activate certificate generation.
+
+### Commands
+To start a new or existing cluster, remembering to rebuild the policy server image in case of .env changes:
+`docker compose up --build`
+Use Ctrl+C once to stop all the docker containers. 
+
+To tear down a cluster without removing the volume (this will delete the database contents!):
+`docker compose down`
+
+To tear down a cluster and remove the volume (this will delete the database contents!):
+`docker compose down -v`
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       DB_PASSWORD: "${DB_PASSWORD:-postgres}"
       DB_USER: "${DB_USER:-postgres}"
       DB_DATABASE: "${DB_DATABASE:-postgres}"
-      CACHE_HOST: "${CACHE_HOST:-redis}"
-      CACHE_MODULE: "${CACHE_MODULE:-redis}"
-      CACHE_PORT: "${CACHE_PORT:-6379}"
+      CACHE_HOST: "redis"
+      CACHE_MODULE: "redis"
+      CACHE_PORT: "6379"
     links:
       - redis
       - postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,11 +6,20 @@ services:
       args:
         - VERSION=master
     ports:
-      - "3000:3000"
+      - "${POLICY_SERVER_PORT:-3000}:${POLICY_SERVER_PORT:-3000}"
+      - "${POLICY_SERVER_PORT_SSL:-443}:${POLICY_SERVER_PORT_SSL:-443}"
     volumes:
       - data:/usr/policy
     env_file:
       - .env
+    environment:
+      DB_HOST: "postgres"
+      DB_PASSWORD: "${DB_PASSWORD:-postgres}"
+      DB_USER: "${DB_USER:-postgres}"
+      DB_DATABASE: "${DB_DATABASE:-postgres}"
+      CACHE_HOST: "${CACHE_HOST:-redis}"
+      CACHE_MODULE: "${CACHE_MODULE:-redis}"
+      CACHE_PORT: "${CACHE_PORT:-6379}"
     links:
       - redis
       - postgres
@@ -23,8 +32,8 @@ services:
   postgres:
     image: postgres:10.19-bullseye
     environment:
-      POSTGRES_PASSWORD: "${DB_PASSWORD}"
-      POSTGRES_USER: "${DB_USER}"
-      POSTGRES_DB: "${DB_DATABASE}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD:-postgres}"
+      POSTGRES_USER: "${DB_USER:-postgres}"
+      POSTGRES_DB: "${DB_DATABASE:-postgres}"
 volumes:
   data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+services:
+  server:
+    build:
+      context: .
+      args:
+        - VERSION=master
+    ports:
+      - "3000:3000"
+    volumes:
+      - data:/usr/policy
+    env_file:
+      - .env
+    links:
+      - redis
+      - postgres
+    depends_on:
+      - redis
+      - postgres
+    command: ["./wait-for-it.sh", "postgres:5432", "--", "npm", "start"]
+  redis:
+    image: redis
+  postgres:
+    image: postgres:10.19-bullseye
+    environment:
+      POSTGRES_PASSWORD: "${DB_PASSWORD}"
+      POSTGRES_USER: "${DB_USER}"
+      POSTGRES_DB: "${DB_DATABASE}"
+volumes:
+  data:

--- a/docker/keys/.gitignore
+++ b/docker/keys/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/docker/webengine-bundle.js
+++ b/docker/webengine-bundle.js
@@ -1,0 +1,132 @@
+// skeleton function for customized downloading and extracting of package information
+const request = require('request');
+const fs = require('fs');
+const UUID = require('uuid');
+const AWS = require('aws-sdk');
+const StreamZip = require('node-stream-zip');
+const BUCKET_NAME = process.env.BUCKET_NAME;
+
+if (process.env.AWS_REGION !== undefined && BUCKET_NAME !== undefined) {
+    AWS.config.update({region: process.env.AWS_REGION});
+}
+
+/**
+ * asynchronous function for downloading the bundle from the given url and extracting its size information
+ * @param package_url - a publicly accessible external url that's used to download the bundle onto the Policy Server
+ * @param cb - a callback function that expects two arguments
+ *      if there was a failure in the process, it should be sent as the first argument. the Policy Server will log it
+ *      the second argument to return must follow the formatted object below
+ *      {
+ *          url: the Policy Server should save a copy of the app bundle somewhere publicly accessible
+ *              this url must be a full resolved url
+ *          size_compressed_bytes: the number of bytes of the compressed downloaded bundle
+ *          size_decompressed_bytes: the number of bytes of the extracted downloaded bundle
+ *      }
+ */
+exports.handleBundle = function (package_url, cb) {
+    if (BUCKET_NAME === undefined || process.env.AWS_REGION === undefined) {
+        return cb();
+    } 
+
+    let compressedSize = 0;
+    let bucketUrl = '';
+    const TMP_FILE_NAME = `${UUID.v4()}.zip`;
+
+    // create a new bucket if it doesn't already exist
+    new AWS.S3().createBucket({Bucket: BUCKET_NAME, ACL: 'public-read'}, err => {
+
+        // OperationAborted errors are expected, as we are potentially 
+        // calling this API multiple times simultaneously
+        if (err && err.code !== 'OperationAborted') {
+            console.log(err);
+            return cb(err);
+        }
+        // read the URL and save it to a buffer variable
+        readUrlToBuffer(package_url)
+            .then(zipBuffer => { // submit the file contents to S3
+                compressedSize = zipBuffer.length;
+                const randomString = UUID.v4();
+                const fileName = `${randomString}.zip`;
+                bucketUrl = `https://${BUCKET_NAME}.s3.amazonaws.com/${fileName}`;
+                // make the bundle publicly accessible
+                const objectParams = {Bucket: BUCKET_NAME, ACL: 'public-read', Key: fileName, Body: zipBuffer};
+                // Create object upload promise
+                return new AWS.S3().putObject(objectParams).promise();
+            })
+            .then(() => { // unzip the contents of the bundle to get its uncompressed data information
+                return streamUrlToTmpFile(bucketUrl, TMP_FILE_NAME);
+            })
+            .then(() => {
+                return unzipAndGetUncompressedSize(TMP_FILE_NAME);
+            })
+            .then(uncompressedSize => {
+                // delete the tmp zip file
+                fs.unlink(TMP_FILE_NAME, () => {
+                    // all the information has been collected
+                    cb(null, {
+                        url: bucketUrl,
+                        size_compressed_bytes: compressedSize,
+                        size_decompressed_bytes: uncompressedSize
+                    });
+                });
+            })
+            .catch(err => {
+                console.log(err);
+                // delete the tmp zip file
+                fs.unlink(TMP_FILE_NAME, () => {
+                    cb(err);
+                });
+            });
+    });
+}
+
+function unzipAndGetUncompressedSize (fileName) {
+    let uncompressedSize = 0;
+
+    return new Promise((resolve, reject) => {
+        const zip = new StreamZip({
+            file: fileName,
+            skipEntryNameValidation: true
+        });
+        zip.on('ready', () => {
+            // iterate through every unzipped entry and count up the file sizes
+            for (const entry of Object.values(zip.entries())) {
+                if (!entry.isDirectory) {
+                    uncompressedSize += entry.size;
+                }
+            }
+            // close the file once you're done
+            zip.close()
+            resolve(uncompressedSize);
+        });
+
+        // Handle errors
+        zip.on('error', err => { 
+            console.log(err);
+            reject(err) 
+        });
+    });
+}
+
+function streamUrlToTmpFile (url, fileName) {
+    return new Promise((resolve, reject) => {
+        request(url)
+            .pipe(fs.createWriteStream(fileName))
+            .on('close', resolve);
+    });
+}
+
+function readUrlToBuffer (url) {
+    return new Promise((resolve, reject) => {
+        let zipBuffer = [];
+
+        request(url)
+            .on('data', data => {
+                zipBuffer.push(data);
+            })
+            .on('close', function () { // file fully downloaded
+                // put the zip contents to a buffer 
+                resolve(Buffer.concat(zipBuffer));
+            });
+    })
+}


### PR DESCRIPTION
Fixes #277 

Depends on #275. Review should wait until merged. 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Adds a new docker folder to the project, where everything can be run in a Docker container environment. Provided are instructions on how to run the environment and some environment variables to be conscious of. WebEngine support, Redis caching and certification generation are all possible.

For this PR review the line in `docker-compose.yml` that specifies the argument for what VERSION the policy server runs on should change to `develop` to bring in the recent required changes for the server to function in docker mode:

```
    build:
      context: .
      args:
        - VERSION=develop
```
