### PR TITLE
Use deployed version of server to avoid dev server issues

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     depends_on:
       - redis
       - postgres
-    command: ["./wait-for-it.sh", "postgres:5432", "--", "npm", "start"]
+    command: ["./wait-for-it.sh", "postgres:5432", "--", "npm", "run", "start-server"]
   redis:
     image: redis
   postgres:


### PR DESCRIPTION
Fixes #287 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
The Docker mode of running the server now uses the built version of the server instead of running it in dev mode, getting around issues of invalid host matching.
