### PR TITLE
Messages and groups with an empty name field still show save button in Safari browser

### DIFF
--- a/src/components/ConsumerMessageDetails.vue
+++ b/src/components/ConsumerMessageDetails.vue
@@ -41,7 +41,7 @@
                         </div>
                     </div>
                     <!-- save button -->
-                    <div v-if="!isNameDefined()">
+                    <div v-if="!isNameDefined">
                         <br>
                         <p class="alert color-bg-red color-white d-table" role="alert">
                             The name field must be defined.
@@ -53,7 +53,7 @@
                             type="submit"
                             class="btn btn-card"
                             data-style="zoom-in"
-                            v-if="!fieldsDisabled && isNameDefined()"
+                            v-if="!fieldsDisabled && isNameDefined"
                             v-on:click="saveGroup()"
                             v-bind:loading="save_button_loading"
                             v-bind:class="{ 'btn-style-green': !message.is_deleted, 'btn-danger': message.is_deleted }">
@@ -225,15 +225,11 @@
                     }
                 });
             },
-            "isNameDefined": function () {
-                if (!this.message.message_category) {
-                    return false; //no name defined
-                }
-
-                return true; //no issues
-            },
         },
         computed: {
+            isNameDefined: function () {
+                return !!this.message.message_category;
+            },
             fieldsDisabled: function () {
                 return (this.message.is_deleted || this.environment != 'STAGING');
             },

--- a/src/components/FunctionalGroupDetails.vue
+++ b/src/components/FunctionalGroupDetails.vue
@@ -128,7 +128,7 @@
                     </div>
                     <!-- save button -->
 
-                    <div v-if="!isNameDefined()">
+                    <div v-if="!isNameDefined">
                         <br>
                         <p class="alert color-bg-red color-white d-table" role="alert">
                             The name field must be defined.
@@ -140,7 +140,7 @@
                             type="submit"
                             class="btn btn-card"
                             data-style="zoom-in"
-                            v-if="!fieldsDisabled && isNameDefined()"
+                            v-if="!fieldsDisabled && isNameDefined"
                             v-on:click="saveGroup()"
                             v-bind:loading="save_button_loading"
                             v-bind:class="{ 'btn-style-green': !fg.is_deleted, 'btn-danger': fg.is_deleted }">
@@ -384,15 +384,11 @@ import { eventBus } from '../main.js';
                     }
                 });
             },
-            "isNameDefined": function () {
-                if (!this.fg.name) {
-                    return false; //no name defined
-                }
-
-                return true; //no issues
-            },
         },
         computed: {
+            isNameDefined: function () {
+                return !!this.fg.name;
+            },
             consentPromptOptions: function () {
                 return this.consent_prompts.map(function (consentPrompt) {
                     return consentPrompt.name;


### PR DESCRIPTION
Fixes #289 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fixes the messages and groups details pages to require a name field before saving in the safari browser. This is done by moving the `isNameDefined` method to the `computed` section because it needs to be actively computed while the page is open.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)