### PR TITLE
Enforce a valid consumer message object

### DIFF
--- a/app/v1/messages/helper.js
+++ b/app/v1/messages/helper.js
@@ -26,6 +26,7 @@ function validatePost (req, res) {
         return;
     }
     for (let i = 0; i < req.body.messages.length; i++) {
+        let foundEnUsObj = false;
         const msg = req.body.messages[i];
         if (!check.string(msg.message_category) || !check.boolean(msg.is_deleted) ) {
             res.parcel
@@ -35,6 +36,9 @@ function validatePost (req, res) {
         }
         for (let j = 0; j < msg.languages.length; j++) {
             const lang = msg.languages[j];
+            if (lang.language_id === 'en-us' && lang.selected === true) {
+                foundEnUsObj = true;
+            }
             if (
                 !check.string(lang.language_id)
                 || !check.boolean(lang.selected)
@@ -52,6 +56,12 @@ function validatePost (req, res) {
                         .setMessage("Required for language: language_id, selected, and at least one of the following: line1, line2, tts, text_body, label");
                     return;
             }
+        }
+        if (!foundEnUsObj) {
+            res.parcel
+                .setStatus(400)
+                .setMessage("There must be a en-us language object defined");
+            return;
         }
     }
 }

--- a/src/components/ConsumerMessageDetails.vue
+++ b/src/components/ConsumerMessageDetails.vue
@@ -184,6 +184,11 @@
                             if (parsed.data.messages && parsed.data.messages.length) {
                                 this.message = parsed.data.messages[0];
                                 console.log(this.message);
+                                // force en-us to exist in the webpage
+                                if (this.message && this.message.languages) {
+                                    const lang = this.message.languages.find(element => element.language_id === 'en-us');
+                                    lang.selected = true;
+                                }
                             } else {
                                 console.log("No message data returned");
                             }

--- a/src/components/common/MessageItem.vue
+++ b/src/components/common/MessageItem.vue
@@ -2,9 +2,10 @@
     <div v-if="item.selected" class="white-box rpc-container">
         <h5></h5>
         <h5>{{ item.language_id }}
+            <!-- Do not allow en-us to be deletable. It is required by core -->
             <i
                 v-on:click="removeLanguage()"
-                v-if="!fieldsDisabled"
+                v-if="!fieldsDisabled && item.language_id !== 'en-us'"
                 class="pointer pull-right fa fa-times hover-color-red"
                 aria-hidden="true">
             </i>


### PR DESCRIPTION
Fixes #212 

This PR is ready for review.

### Risk
This PR makes minor API changes.

### Summary
The policy server could produce a consumer messages object that is invalid to sdl_core, and can cause policy table failures. This PR fixes that by enforcing the en-us object to exist in every message. No empty strings are already enforced by the server. When creating a new consumer message, the en-us language object already exists and is undeletable. The object is allowed to be empty. 