### PR TITLE
Fix broken message create test

### DIFF
--- a/test/api/v1/messages/messages.js
+++ b/test/api/v1/messages/messages.js
@@ -26,7 +26,11 @@ common.startTest('should create new message', async function () {
             {
                 message_category: 'Blarg',
                 is_deleted: false,
-                languages: []
+                languages: [{
+                    language_id: 'en-us',
+                    selected: true,
+                    line1: ''
+                }]
             }
         ]
     });


### PR DESCRIPTION
This PR resolves #305 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Fixes a message create test that did not include the required en-us object in the languages object