### PR TITLE
Prevent making custom vehicle data with invalid characters

### DIFF
--- a/src/components/common/VehicleDataItem.vue
+++ b/src/components/common/VehicleDataItem.vue
@@ -22,7 +22,7 @@
                     <label class="col-sm-2 col-form-label">{{ propsDisplay[propName].display.toUpperCase() }}</label>
                     <div class="col-sm-10">
                         <input v-model="item[propName]" :disabled="fieldsDisabled || (level === 1 && item.id)" class="form-control"
-                            @input="updateName(propName, $event.target.value)">
+                            @input="updateNameOrKey(propName, $event.target.value)">
                     </div>
                     <p v-if="findCommonParams(item[propName]) === 'CUSTOM'">
                         <br>A parent or top level vehicle data item with this name already exists! By saving, you will overwrite the previously existing vehicle data.
@@ -57,7 +57,7 @@
                     <label class="col-sm-2 col-form-label">{{ propsDisplay[propName].display.toUpperCase() }}</label>
                     <div class="col-sm-10">
                         <input v-model="item[propName]" :disabled="fieldsDisabled" class="form-control"
-                            @input="updateName(propName, $event.target.value)">
+                            @input="updateNameOrKey(propName, $event.target.value)">
                     </div>
                 </div>
             </template>
@@ -172,7 +172,7 @@
                 }
                 this.item[propName] = Math.max(0, Math.round(val));
             },
-            updateName: function (propName, val) {
+            updateNameOrKey: function (propName, val) {
                 // Checks for the invalid characters "!@#$%^&*", and whitespace characters that would be rejected by SDL Core
                 if (/[!@#$%^&*\s]/g.test(val)) {
                     return this.item[propName] = null;

--- a/src/components/common/VehicleDataItem.vue
+++ b/src/components/common/VehicleDataItem.vue
@@ -21,7 +21,8 @@
                 <div class="form-group row">
                     <label class="col-sm-2 col-form-label">{{ propsDisplay[propName].display.toUpperCase() }}</label>
                     <div class="col-sm-10">
-                        <input v-model="item[propName]" :disabled="fieldsDisabled || (level === 1 && item.id)" class="form-control">
+                        <input v-model="item[propName]" :disabled="fieldsDisabled || (level === 1 && item.id)" class="form-control"
+                            @input="updateName(propName, $event.target.value)">
                     </div>
                     <p v-if="findCommonParams(item[propName]) === 'CUSTOM'">
                         <br>A parent or top level vehicle data item with this name already exists! By saving, you will overwrite the previously existing vehicle data.
@@ -55,7 +56,8 @@
                 <div class="form-group row">
                     <label class="col-sm-2 col-form-label">{{ propsDisplay[propName].display.toUpperCase() }}</label>
                     <div class="col-sm-10">
-                        <input v-model="item[propName]" :disabled="fieldsDisabled" class="form-control">
+                        <input v-model="item[propName]" :disabled="fieldsDisabled" class="form-control"
+                            @input="updateName(propName, $event.target.value)">
                     </div>
                 </div>
             </template>
@@ -169,6 +171,12 @@
                     return this.item[propName] = null;
                 }
                 this.item[propName] = Math.max(0, Math.round(val));
+            },
+            updateName: function (propName, val) {
+                // Checks for the invalid characters "!@#$%^&*", and whitespace characters that would be rejected by SDL Core
+                if (/[!@#$%^&*\s]/g.test(val)) {
+                    return this.item[propName] = null;
+                }
             },
             updateIntegerNumber: function (propName, val) {
                 if (val === "-") {


### PR DESCRIPTION
Fixes #309 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested with the SDL Core 8.2.0 Release Candidate.

### Summary
Fixes the case where Custom Vehicle Data items could be created that would not be accepted by SDL Core. Trying to type any of the characters `!@#$%^&*` in the UI fields for Custom Vehicle Data's Name or Key will clear the current input to prevent these items from being saved.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)