### PR TITLE
Bugfix/webengine docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,14 @@
 # Copyright (c) 2022, Livio, Inc.
-FROM node:12
+FROM debian:11.7
 
 ARG VERSION=master 
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
         openssl \
         curl \
+        wget \
+        xz-utils \
         git
 
 # Download SDL Server from github
@@ -14,10 +17,17 @@ WORKDIR /usr
 RUN mkdir /usr/policy
 RUN git clone https://github.com/smartdevicelink/sdl_server.git /usr/policy -b $VERSION --depth=1
 
+# Install node + npm
+RUN wget https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.xz
+RUN tar xvf node-v16.20.1-linux-x64.tar.xz
+RUN chmod +rx node-v16.20.1-linux-x64/bin/node node-v16.20.1-linux-x64/bin/npm
+RUN ln -s /usr/node-v16.20.1-linux-x64/bin/node /usr/local/bin/node
+RUN ln -s /usr/node-v16.20.1-linux-x64/bin/npm /usr/local/bin/npm
+
 WORKDIR /usr/policy
 
-RUN npm install
-RUN npm install request aws-sdk node-stream-zip --save
+RUN npm install --legacy-peer-deps
+RUN npm install aws-sdk@2.1453.0 node-stream-zip@1.15.0 --save --legacy-peer-deps
 
 COPY wait-for-it.sh wait-for-it.sh
 COPY keys customizable/ca


### PR DESCRIPTION
This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Updates the Dockerfile to use the updated server code, including replacing the request library with built-ins. Also fixes an issue with AWS in how it sets up permissions for creating new buckets. The code now assumes you have a bucket already set up instead of trying to create one for you if it does not exist. For some reason the standard Node docker images were not working and also specifically node 16 had to be used for this. I just took the base debian image Node is typically built from and "manually" installed node and npm into the container.

To test the docker compose file make sure you edit the .yml file to change the VERSION argument to use this branch name instead of master as it will pull from this repository `VERSION=bugfix/webengine-docker`

If you have an existing policy server docker compose already set up from previous runs make sure you wipe everything out with `docker compose down -v` first.
